### PR TITLE
[MNG-5446] AM/PM inconsistency in mng-3827 and mng-3864 ITs?

### DIFF
--- a/core-it-suite/src/test/resources/mng-3827/pom.xml
+++ b/core-it-suite/src/test/resources/mng-3827/pom.xml
@@ -60,7 +60,7 @@ under the License.
           <characterParam>X</characterParam>
           <stringParam>Hello World!</stringParam>
           <fileParam>pom.xml</fileParam>
-          <dateParam>2008-11-09 11:59:03.0 PM</dateParam>
+          <dateParam>2008-11-09 11:59:03.0 AM</dateParam>
           <urlParam>http://maven.apache.org/</urlParam>
           <stringParams>
             <stringParam>one</stringParam>

--- a/core-it-suite/src/test/resources/mng-3864/pom.xml
+++ b/core-it-suite/src/test/resources/mng-3864/pom.xml
@@ -66,7 +66,7 @@ under the License.
               <characterParam>X</characterParam>
               <stringParam>Hello World!</stringParam>
               <fileParam>pom.xml</fileParam>
-              <dateParam>2008-11-09 11:59:03.0 PM</dateParam>
+              <dateParam>2008-11-09 11:59:03.0 AM</dateParam>
               <urlParam>http://maven.apache.org/</urlParam>
               <stringParams>
                 <stringParam>one</stringParam>


### PR DESCRIPTION
See https://jira.codehaus.org/browse/MNG-5446 - Maven appears to ignore the PM setting when parsing "2008-11-09 11:59:03.0 PM". This is because the Plexus DateConverter has historically used 'HH'='Hour in day (0-23)' to parse the hours instead of 'hh'='Hour in am/pm (1-12)'. The parsed date-time is therefore written back out as "2008-11-09 11:59:03" instead of "2008-11-09 23:59:03".

If this behaviour is wrong and can be safely fixed then updating the ITs to use "2008-11-09 11:59:03.0 AM" would avoid future IT failures if/when the Date conversion is finally fixed.

If however the old behaviour should be maintained then no change is required in the ITs. (I'd like to know because I'm doing some refactoring of the Sisu-Plexus internals to improve re-use and consistency.)

BTW, does anyone happen to know of plugins whose goals/mojos have Date parameters?
