### PR TITLE
MNG-5577 avoid false positives for different errors

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2576MakeLikeReactorTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2576MakeLikeReactorTest.java
@@ -232,7 +232,7 @@ public class MavenITmng2576MakeLikeReactorTest
     }
 
     /**
-     * Verify that the project list can also specify aritfact ids.
+     * Verify that the project list can also specify artifact ids.
      */
     public void testitMatchesByArtifactId()
         throws Exception

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4385LifecycleMappingFromExtensionInReactorTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4385LifecycleMappingFromExtensionInReactorTest.java
@@ -58,6 +58,10 @@ public class MavenITmng4385LifecycleMappingFromExtensionInReactorTest
         catch( VerificationException e )
         {
             // expected, should fail
+            String msg = e.getMessage();
+
+            assertTrue( "Failure should be due to unknown packaging", msg.contains( "Unknown packaging: it-packaging" ));
+            assertTrue( "Failure should be due to sub-b project", msg.contains( "The project org.apache.maven.its.mng4385:sub-b:0.1" ));
         }
         verifier.resetStreams();
     }

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5230MakeReactorWithExcludesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5230MakeReactorWithExcludesTest.java
@@ -231,7 +231,7 @@ public class MavenITmng5230MakeReactorWithExcludesTest
     }
 
     /**
-     * Verify that the project list exclude can also specify aritfact ids.
+     * Verify that the project list exclude can also specify artifact ids.
      */
     public void testitMatchesByArtifactIdExclude()
         throws Exception

--- a/core-it-suite/src/test/resources/mng-0449/repo/org/apache/maven/its/mng0449/maven-it-plugin-b/0.1/maven-it-plugin-b-0.1.pom
+++ b/core-it-suite/src/test/resources/mng-0449/repo/org/apache/maven/its/mng0449/maven-it-plugin-b/0.1/maven-it-plugin-b-0.1.pom
@@ -29,7 +29,7 @@ under the License.
 
   <name>Maven Integration Test Plugin :: Packaging</name>
   <description>
-    A test plugin that defines a custom aritfact handler ("it-artifact") and a new packaging type ("it-packaging").
+    A test plugin that defines a custom artifact handler ("it-artifact") and a new packaging type ("it-packaging").
   </description>
   <inceptionYear>2006</inceptionYear>
 

--- a/core-it-support/core-it-plugins/maven-it-plugin-packaging/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-packaging/pom.xml
@@ -33,7 +33,7 @@ under the License.
 
   <name>Maven IT Plugin :: Packaging</name>
   <description>
-    A test plugin that defines a custom aritfact handler ("it-artifact") and a new packaging type ("it-packaging").
+    A test plugin that defines a custom artifact handler ("it-artifact") and a new packaging type ("it-packaging").
   </description>
   <inceptionYear>2006</inceptionYear>
 


### PR DESCRIPTION
I ran into a false positive with this test while investigating MNG-5577. The build was failing with an `NPE`, which was enough to make it pass. It should fail due to an unavailable exception. This change checks that the build fails for the expected reason.

Also, a typo fix.