### PR TITLE
[MNG-6613] Avoid a connection to apache.org when this test runs.

### DIFF
--- a/core-it-suite/src/test/resources/mng-3461/test-3/settings-template.xml
+++ b/core-it-suite/src/test/resources/mng-3461/test-3/settings-template.xml
@@ -44,12 +44,12 @@ under the License.
   <mirrors>
     <mirror>
       <id>central</id>
-      <url>http://maven.apache.org/null</url>
+      <url>https://maven.apache.org/null</url>
       <!--
       The explicit mismatch with maven-core-it should be dominant over the wildcard, even if the wildcard
       is given first.
       -->
-      <mirrorOf>*,!maven-core-it</mirrorOf>
+      <mirrorOf>*,!maven-core-it,!central</mirrorOf>
     </mirror>
   </mirrors>
 </settings>


### PR DESCRIPTION
This test runs with two repositories configured (maven-core-its and
central). Make sure that both are excluded from this mirror's
configuration, so it isn't used.

As a fallback, in case it is used, at least make it a secure connection.