### PR TITLE
[MNG-5760] Add integration tests for "resume" feature

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5760ResumeFeatureTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5760ResumeFeatureTest.java
@@ -1,0 +1,185 @@
+package org.apache.maven.it;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.it.util.ResourceExtractor;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.StreamSupport;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * This is a collection of test cases for <a href="https://issues.apache.org/jira/browse/MNG-5760">MNG-5760</a>,
+ * <code>--resume</code> / <code>-r</code> in case of build failures.
+ *
+ * The test uses a multi-module project with three modules:
+ * <ul>
+ *     <li>module-a</li>
+ *     <li>module-b</li>
+ *     <li>module-c</li> (depends on module-b)
+ * </ul>
+ *
+ * @author Maarten Mulders
+ * @author Martin Kanters
+ */
+public class MavenITmng5760ResumeFeatureTest extends AbstractMavenIntegrationTestCase {
+    private final File testDir;
+
+    public MavenITmng5760ResumeFeatureTest() throws IOException {
+        super( "[3.7.0,)" );
+        this.testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-5760-resume-feature" );
+    }
+
+    /**
+     * Tests that the hint at the end of a failed build mentions <code>--resume</code> instead of <code>--resume-from</code>.
+     */
+    public void testShouldSuggestToResumeWithoutArgs() throws Exception
+    {
+        final Verifier verifier = newVerifier( testDir.getAbsolutePath() );
+        verifier.addCliOption( "-Dmodule-b.fail=true" );
+
+        try
+        {
+            verifier.executeGoal( "test" );
+            fail( "Expected this invocation to fail" );
+        }
+        catch ( final VerificationException ve )
+        {
+            verifier.verifyTextInLog( "mvn <args> -r" );
+            verifyTextNotInLog( verifier, "mvn <args> -rf :module-b" );
+        }
+        finally
+        {
+            verifier.resetStreams();
+        }
+    }
+
+    public void testShouldCreateResumptionFile() throws Exception
+    {
+        final Verifier verifier = newVerifier( testDir.getAbsolutePath() );
+        verifier.addCliOption( "-Dmodule-b.fail=true" );
+
+        try
+        {
+            verifier.executeGoal( "test" );
+            fail( "Expected this invocation to fail" );
+        }
+        catch ( final VerificationException ve )
+        {
+            final Path resumeProperties = Paths.get(testDir.getAbsolutePath(), "target", "resume.properties");
+            verifier.assertFilePresent( resumeProperties.toAbsolutePath().toString() );
+
+
+            Properties expected = new Properties();
+            expected.put( "resumeFrom", "org.apache.maven.its.mng5760:module-b");
+
+            verifyFileContainsProperties( resumeProperties, expected );
+        }
+        finally
+        {
+            verifier.resetStreams();
+        }
+    }
+
+    public void testShouldSkipSuccessfulProjects() throws Exception
+    {
+        final Verifier verifier = newVerifier( testDir.getAbsolutePath() );
+        verifier.addCliOption( "-Dmodule-a.fail=true" );
+        verifier.addCliOption( "--fail-at-end");
+
+        try
+        {
+            verifier.executeGoal( "test" );
+            fail( "Expected this invocation to fail" );
+        }
+        catch ( final VerificationException ve )
+        {
+            final Path resumeProperties = Paths.get(testDir.getAbsolutePath(), "target", "resume.properties");
+            verifier.assertFilePresent( resumeProperties.toAbsolutePath().toString() );
+
+
+            Properties expected = new Properties();
+            expected.put( "resumeFrom", "org.apache.maven.its.mng5760:module-a");
+            expected.put( "excludedProjects", "org.apache.maven.its.mng5760:module-b, org.apache.maven.its.mng5760:module-c");
+
+            verifyFileContainsProperties( resumeProperties, expected );
+        }
+        finally
+        {
+            verifier.resetStreams();
+        }
+    }
+
+    /**
+     * Throws an exception if the text <strong>is</strong> present in the log.
+     *
+     * @param verifier the verifier to use
+     * @param text the text to assert present
+     * @throws VerificationException if text is not found in log
+     */
+    private void verifyTextNotInLog( Verifier verifier, String text )
+            throws VerificationException
+    {
+        List<String> lines = verifier.loadFile( verifier.getBasedir(), verifier.getLogFileName(), false );
+
+        for ( String line : lines )
+        {
+            if ( Verifier.stripAnsi( line ).contains( text ) )
+            {
+                throw new VerificationException( "Text found in log: " + text );
+            }
+        }
+    }
+
+    /**
+     * Throws an exception if the specified {@link Properties} are not present in the file. Checks for both key and
+     * value of the expected properties to be present.
+     * @param path Path the a file
+     * @param expectedProperties Expected properties inside the specified file
+     * @throws VerificationException When the specified file could not be read.
+     */
+    private void verifyFileContainsProperties( Path path, Properties expectedProperties )
+            throws VerificationException
+    {
+        Properties foundProperties = new Properties();
+        try ( Reader reader = Files.newBufferedReader( path ) )
+        {
+            foundProperties.load( reader );
+        }
+        catch ( IOException e )
+        {
+            throw new VerificationException( "Could not verify contents of " + path.toString(), e );
+        }
+
+        expectedProperties.forEach( ( key, value ) -> {
+            assertThat( foundProperties.containsKey( key ), is( true ) );
+            assertThat( foundProperties.get( key ), is( value ) );
+        });
+    }
+}

--- a/core-it-suite/src/test/resources/mng-5760-resume-feature/module-a/pom.xml
+++ b/core-it-suite/src/test/resources/mng-5760-resume-feature/module-a/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>module-a</artifactId>
+
+    <parent>
+        <groupId>org.apache.maven.its.mng5760</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0</version>
+    </parent>
+
+</project>

--- a/core-it-suite/src/test/resources/mng-5760-resume-feature/module-a/src/test/java/org/apache/maven/it/TestCase.java
+++ b/core-it-suite/src/test/resources/mng-5760-resume-feature/module-a/src/test/java/org/apache/maven/it/TestCase.java
@@ -1,0 +1,36 @@
+package org.apache.maven.it;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class TestCase
+{
+    @Test
+    public void testCase()
+    {
+        if ( Boolean.getBoolean("module-a.fail") )
+        {
+            fail("Deliberately fail test case in module A");
+        }
+    }
+}

--- a/core-it-suite/src/test/resources/mng-5760-resume-feature/module-b/pom.xml
+++ b/core-it-suite/src/test/resources/mng-5760-resume-feature/module-b/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>module-b</artifactId>
+
+    <parent>
+        <groupId>org.apache.maven.its.mng5760</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0</version>
+    </parent>
+
+</project>

--- a/core-it-suite/src/test/resources/mng-5760-resume-feature/module-b/src/test/java/org/apache/maven/it/TestCase.java
+++ b/core-it-suite/src/test/resources/mng-5760-resume-feature/module-b/src/test/java/org/apache/maven/it/TestCase.java
@@ -1,0 +1,36 @@
+package org.apache.maven.it;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class TestCase
+{
+    @Test
+    public void testCase()
+    {
+        if ( Boolean.getBoolean("module-b.fail") )
+        {
+            fail("Deliberately fail test case in module B");
+        }
+    }
+}

--- a/core-it-suite/src/test/resources/mng-5760-resume-feature/module-c/pom.xml
+++ b/core-it-suite/src/test/resources/mng-5760-resume-feature/module-c/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>module-c</artifactId>
+
+    <parent>
+        <groupId>org.apache.maven.its.mng5760</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven.its.mng5760</groupId>
+            <artifactId>module-b</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/core-it-suite/src/test/resources/mng-5760-resume-feature/module-c/src/test/java/org/apache/maven/it/TestCase.java
+++ b/core-it-suite/src/test/resources/mng-5760-resume-feature/module-c/src/test/java/org/apache/maven/it/TestCase.java
@@ -1,0 +1,36 @@
+package org.apache.maven.it;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class TestCase
+{
+    @Test
+    public void testCase()
+    {
+        if ( Boolean.getBoolean("module-c.fail") )
+        {
+            fail("Deliberately fail test case in module C");
+        }
+    }
+}

--- a/core-it-suite/src/test/resources/mng-5760-resume-feature/pom.xml
+++ b/core-it-suite/src/test/resources/mng-5760-resume-feature/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.its.mng5760</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0</version>
+
+    <packaging>pom</packaging>
+
+    <name>Maven Integration Test :: MNG-5760</name>
+    <description>
+        Tests for the --resume flag.
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+        <module>module-c</module>
+    </modules>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>


### PR DESCRIPTION
Integration tests for the new "--resume / -r" feature. Works like "--resume-from / -rf", except you don't need to specify where to resume the build.

Corresponding pull request on Maven Core: https://github.com/apache/maven/pull/342.