### PR TITLE
[MNG-6974] fix mng5175 by waiting longer for read timeout to happen

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5175WagonHttpTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5175WagonHttpTest.java
@@ -64,7 +64,8 @@ public class MavenITmng5175WagonHttpTest
             {
                 try
                 {
-                    Thread.sleep( 15 );
+                    // wait long enough for read timeout to happen in client
+                    Thread.sleep( 100 );
                 }
                 catch ( InterruptedException e )
                 {


### PR DESCRIPTION
spotted by @michael-o:
> the thread sleeps for 15 ms and the read timeout is set to 10 ms. I consider this is to be a racing condition

fixes MNG-6974

This PR should fix build stability problems in https://github.com/apache/maven/pull/368