### PR TITLE
[MNG-7022] Remove o.a.m.lifecycle.mapping.Lifecycle optional mojos ba…

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4338OptionalMojosTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4338OptionalMojosTest.java
@@ -35,7 +35,7 @@ public class MavenITmng4338OptionalMojosTest
 
     public MavenITmng4338OptionalMojosTest()
     {
-        super( "[3.0,)" );
+        super( "[3.0,4.0.0-alpha-1)" );
     }
 
     /**


### PR DESCRIPTION
…ckward compat code

Disable test which still declares optional mojos. The test runs fine
when optional mojos are removed from components.xml.