### PR TITLE
[MNG-4660] Increase usefulness of logging

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4660OutdatedPackagedArtifact.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4660OutdatedPackagedArtifact.java
@@ -106,7 +106,7 @@ public class MavenITmng4660OutdatedPackagedArtifact extends AbstractMavenIntegra
         verifier3.verifyErrorFreeLog();
         try
         {
-            verifier3.verifyTextInLog( "Packaged artifact is not up-to-date" );
+            verifier3.verifyTextInLog( "Packaged artifact for module-a is not up-to-date" );
         }
         catch ( VerificationException e )
         {


### PR DESCRIPTION
When the user resumes a build, they could see a message "Packaged artifact is not up-to-date compared to the build output directory". This could even be logged multiple times for one build. It was unclear why it was logged and what a user could do to address it. This test accompanies https://github.com/apache/maven/pull/414.