### PR TITLE
[MNG-6114] Elements from the global settings should be ordered before…

### DIFF
--- a/core-it-suite/src/test/resources/mng-5771-core-extensions/settings-template-mirror-auth.xml
+++ b/core-it-suite/src/test/resources/mng-5771-core-extensions/settings-template-mirror-auth.xml
@@ -12,7 +12,7 @@
       <id>repoman</id>
       <name>Mirror</name>
       <url>http://localhost:@port@</url>
-      <mirrorOf>external:*</mirrorOf>
+      <mirrorOf>*</mirrorOf>
     </mirror>
   </mirrors>
 


### PR DESCRIPTION
… elements from the user settings

Central from global settings with 'file:' comes first and is ignored by the
mirrorOf definition. The next central definition is ignored too due to
MNG-7018/MNG-5984. As long as these issues aren't resolved we need to
mirror even local repos to make the IT work as intended.