### PR TITLE
[MNG-6972] Allow access to org.apache.maven.graph

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6972AllowAccessToGraphPackageTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6972AllowAccessToGraphPackageTest.java
@@ -35,7 +35,7 @@ public class MavenITmng6972AllowAccessToGraphPackageTest
         super( "[4.0.0-alpha-1,)" );
     }
 
-    public void testitMNG6972()
+    public void testit()
         throws Exception
     {
 
@@ -51,17 +51,17 @@ public class MavenITmng6972AllowAccessToGraphPackageTest
          * unstable test results. Fortunately, the verifier
          * makes it easy to do this.
          */
-        verifier = new Verifier( testDir.getAbsolutePath() );
+        verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.deleteArtifact( "mng-6972-allow-access-to-graph-package", "build-plugin", "1.0", "jar" );
         verifier.deleteArtifact( "mng-6972-allow-access-to-graph-package", "using-module", "1.0", "jar" );
 
-        verifier = new Verifier( new File( testDir.getAbsolutePath(), "build-plugin" ).getAbsolutePath() );
+        verifier = newVerifier( new File( testDir.getAbsolutePath(), "build-plugin" ).getAbsolutePath() );
         verifier.getSystemProperties().put( "maven.multiModuleProjectDirectory", testDir.getAbsolutePath() );
         verifier.executeGoal( "install" );
         verifier.verifyErrorFreeLog();
         verifier.resetStreams();
 
-        verifier = new Verifier( new File( testDir.getAbsolutePath(), "using-module" ).getAbsolutePath() );
+        verifier = newVerifier( new File( testDir.getAbsolutePath(), "using-module" ).getAbsolutePath() );
         verifier.getSystemProperties().put( "maven.multiModuleProjectDirectory", testDir.getAbsolutePath() );
         verifier.executeGoal( "install" );
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/resources/bootstrap/group-12/pom.xml
+++ b/core-it-suite/src/test/resources/bootstrap/group-12/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.bootstrap</groupId>
+    <artifactId>maven-it-boostrap</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <groupId>org.apache.maven.its.bootstrap</groupId>
+  <artifactId>group-12</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+
+  <name>Maven Integration Test :: Boostrap :: Group-12</name>
+
+  <properties>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>3.3.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-component-metadata</artifactId>
+      <version>1.5.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-component-annotations</artifactId>
+      <version>1.5.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>1.4.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-java</artifactId>
+      <version>1.0.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+	  <artifactId>maven-common-artifact-filters</artifactId>
+      <version>3.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+	  <artifactId>maven-artifact-transfer</artifactId>
+      <version>0.11.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+	  <artifactId>asm</artifactId>
+      <version>7.2</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/core-it-suite/src/test/resources/bootstrap/pom.xml
+++ b/core-it-suite/src/test/resources/bootstrap/pom.xml
@@ -48,6 +48,7 @@ under the License.
     <module>group-9</module>
     <module>group-10</module>
     <module>group-11</module>
+    <module>group-12</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
Use a fresh, preconfigured verifier which has global settings set.

This issue can be observed when Maven is ran with MNG-4645 where
no preconfigured Maven Central is in global settings.

This closes #94