### PR TITLE
[MNG-4963] Parent POM not downloaded when settings define global mirr…

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4963ParentResolutionFromMirrorTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4963ParentResolutionFromMirrorTest.java
@@ -55,6 +55,10 @@ public class MavenITmng4963ParentResolutionFromMirrorTest
         verifier.addCliOption( "-s" );
         verifier.addCliOption( "settings.xml" );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        if ( matchesVersionRange( "[4.0.0-alpha-1,)" ) )
+        {
+            verifier.addCliOption( "-Pit-defaults-4.0.0" );
+        }
         verifier.executeGoal( "validate" );
         verifier.verifyErrorFreeLog();
         verifier.resetStreams();

--- a/core-it-suite/src/test/resources/mng-4963/settings-template.xml
+++ b/core-it-suite/src/test/resources/mng-4963/settings-template.xml
@@ -46,6 +46,24 @@ under the License.
         </repository>
       </repositories>
     </profile>
+    <profile>
+      <!--
+      NOTE: Since Maven Central (release repo) is not added implicitly by Maven Core anymore we cannot rely on the implicit behavior of MNG-4963.
+      -->
+      <id>it-defaults-4.0.0</id>
+      <repositories>
+        <repository>
+          <id>maven-core-it-4.0.0</id>
+          <url>@baseurl@/repo</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
   </profiles>
   <activeProfiles>
     <activeProfile>it-defaults</activeProfile>


### PR DESCRIPTION
…or and one snapshot repo but no other release repository

This IT was written with implicit black magic in mind. A mirror simply exchanges
a URL of repo with another one while retaining the entire config for
releases/snapshots. Logically this IT should have failed because there is no
release repo. But it works because Maven adds Maven Central internally which is
a release repo. For MNG-4645 one has to add a release repo in the settings to
mimic that behavior.

This closes #96