### PR TITLE
[MNG-7051] When an optional profile could not be found, an info message should be thrown instead of a warning.

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7051OptionalProfileActivationTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7051OptionalProfileActivationTest.java
@@ -72,7 +72,7 @@ public class MavenITmng7051OptionalProfileActivationTest
 
         verifier.executeGoal( "validate" );
         verifier.verifyErrorFreeLog();
-        verifier.verifyTextInLog( "[WARNING] The requested optional profiles [non-existing-profile] could not be activated or deactivated because they do not exist." );
+        verifier.verifyTextInLog( "[INFO] The requested optional profiles [non-existing-profile] could not be activated or deactivated because they do not exist." );
     }
 
     /**
@@ -89,7 +89,7 @@ public class MavenITmng7051OptionalProfileActivationTest
 
         verifier.executeGoal( "validate" );
         verifier.verifyErrorFreeLog();
-        verifier.verifyTextInLog( "[WARNING] The requested optional profiles [non-existing-profile] could not be activated or deactivated because they do not exist." );
+        verifier.verifyTextInLog( "[INFO] The requested optional profiles [non-existing-profile] could not be activated or deactivated because they do not exist." );
     }
 
     /**
@@ -106,7 +106,7 @@ public class MavenITmng7051OptionalProfileActivationTest
 
         verifier.executeGoal( "validate" );
         verifier.verifyErrorFreeLog();
-        verifier.verifyTextInLog( "[WARNING] The requested optional profiles [non-existing-profile] could not be activated or deactivated because they do not exist." );
+        verifier.verifyTextInLog( "[INFO] The requested optional profiles [non-existing-profile] could not be activated or deactivated because they do not exist." );
     }
 
     /**
@@ -123,6 +123,6 @@ public class MavenITmng7051OptionalProfileActivationTest
 
         verifier.executeGoal( "validate" );
         verifier.verifyErrorFreeLog();
-        verifier.verifyTextInLog( "[WARNING] The requested optional profiles [non-existing-profile] could not be activated or deactivated because they do not exist." );
+        verifier.verifyTextInLog( "[INFO] The requested optional profiles [non-existing-profile] could not be activated or deactivated because they do not exist." );
     }
 }


### PR DESCRIPTION
Needed for https://github.com/apache/maven/pull/453