### PR TITLE
[MNG-7045] Upgrade to IT to use Groovy 4.0.0-alpha-2

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7045DropUselessAndOutdatedCdiApiTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7045DropUselessAndOutdatedCdiApiTest.java
@@ -17,13 +17,13 @@ public class MavenITmng7045DropUselessAndOutdatedCdiApiTest
     }
 
     @Test
-    public void testit()
+    public void testShouldNotLeakCdiApi()
         throws IOException, VerificationException
     {
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng7045" );
         Verifier verifier = newVerifier( testDir.getAbsolutePath()) ;
 
-        verifier.executeGoal( "process-classes") ;
+        verifier.executeGoal( "process-classes" );
         verifier.resetStreams();
         verifier.verifyErrorFreeLog();
     }

--- a/core-it-suite/src/test/resources/mng7045/pom.xml
+++ b/core-it-suite/src/test/resources/mng7045/pom.xml
@@ -7,7 +7,7 @@
 
   <name>Maven Integration Test :: MNG-7045</name>
   <description>
-    Do a Maven exec-java which executes some CDI 2.0 code which would fail if maven leaks CDI API 1.0.
+    Runs a Groovy script which refers some CDI 2.0 code. The script fails if Maven would leak CDI API 1.0.
   </description>
 
   <dependencies>
@@ -53,9 +53,15 @@ javax.enterprise.inject.Instance.class.getDeclaredMethod("stream")
         </configuration>
         <dependencies>
           <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-ant</artifactId>
+            <version>4.0.0-alpha-2</version>
+            <scope>runtime</scope>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
-            <version>3.0.7</version>
+            <version>4.0.0-alpha-2</version>
             <scope>runtime</scope>
           </dependency>
         </dependencies>


### PR DESCRIPTION
The IT for MNG-7045 [fails on Java 17 early access builds](https://github.com/apache/maven/pull/456) due to Groovy 3 using an older version of ASM. This MR upgrades to the latest Groovy release, the only one with a version of ASM that supports Java 17.