### PR TITLE
[GitHub CI] Use the loopback address for connecting to an in-process web server

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0146InstallerSnapshotNaming.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0146InstallerSnapshotNaming.java
@@ -86,7 +86,7 @@ public class MavenIT0146InstallerSnapshotNaming
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
 
         Properties properties = verifier.newDefaultFilterProperties();
-        properties.setProperty( "@host@", InetAddress.getLocalHost().getCanonicalHostName() );
+        properties.setProperty( "@host@", InetAddress.getLoopbackAddress().getCanonicalHostName() );
         properties.setProperty( "@port@", Integer.toString( port ) );
 
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", properties );
@@ -125,7 +125,7 @@ public class MavenIT0146InstallerSnapshotNaming
         verifier = newVerifier( testDir.getAbsolutePath() );
 
         Properties properties = verifier.newDefaultFilterProperties();
-        properties.setProperty( "@host@", InetAddress.getLocalHost().getCanonicalHostName() );
+        properties.setProperty( "@host@", InetAddress.getLoopbackAddress().getCanonicalHostName() );
         properties.setProperty( "@port@", Integer.toString( port ) );
 
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", properties );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2387InactiveProxyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2387InactiveProxyTest.java
@@ -119,7 +119,7 @@ public class MavenITmng2387InactiveProxyTest
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
 
         Properties properties = verifier.newDefaultFilterProperties();
-        properties.setProperty( "@host@", InetAddress.getLocalHost().getCanonicalHostName() );
+        properties.setProperty( "@host@", InetAddress.getLoopbackAddress().getCanonicalHostName() );
         properties.setProperty( "@port@", Integer.toString( port ) );
         properties.setProperty( "@proxyPort@", Integer.toString( proxyPort ) );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", properties );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4991NonProxyHostsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4991NonProxyHostsTest.java
@@ -93,7 +93,7 @@ public class MavenITmng4991NonProxyHostsTest
             filterProps.setProperty( "@port@", Integer.toString( port ) );
             int proxyPort = ( (NetworkConnector) proxy.getConnectors()[0] ).getLocalPort();
             filterProps.setProperty( "@proxyPort@", Integer.toString( proxyPort ) );
-            filterProps.setProperty( "@localhost@", InetAddress.getLocalHost().getCanonicalHostName() );
+            filterProps.setProperty( "@localhost@", InetAddress.getLoopbackAddress().getCanonicalHostName() );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliOption( "-s" );
             verifier.addCliOption( "settings.xml" );


### PR DESCRIPTION
This may resolve the connection issues we sometimes see in GitHub
Actions, where the Maven process that is being tested cannot connect
to the Jetty server that was just started.