### PR TITLE
Fix IT0138: the m-plugin-p mojo is removed from maven-plugin lifecycle

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0138PluginLifecycleTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0138PluginLifecycleTest.java
@@ -57,7 +57,8 @@ public class MavenIT0138PluginLifecycleTest
         verifier.assertFilePresent( "target/compiler-test-compile.txt" );
         verifier.assertFilePresent( "target/surefire-test.txt" );
         verifier.assertFilePresent( "target/jar-jar.txt" );
-        verifier.assertFilePresent( "target/plugin-add-plugin-artifact-metadata.txt" );
+        // maven-plugin lifecycle has this extra mojo removed (as Resolver handles group level metadata now)
+        // verifier.assertFilePresent( "target/plugin-add-plugin-artifact-metadata.txt" );
         verifier.assertFilePresent( "target/install-install.txt" );
         if ( matchesVersionRange( "(,2.2.0)" ) )
         {


### PR DESCRIPTION
The extra mojo is not needed anymore, as Resolver handles the group
level metadata now.

Related to PR https://github.com/apache/maven/pull/555