### PR TITLE
Up enforcer version

### DIFF
--- a/core-it-suite/src/test/resources/mng-5840-relative-path-range-negative/child/pom.xml
+++ b/core-it-suite/src/test/resources/mng-5840-relative-path-range-negative/child/pom.xml
@@ -17,7 +17,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.4</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <inherited>false</inherited>

--- a/core-it-suite/src/test/resources/mng-5840-relative-path-range-positive/child/pom.xml
+++ b/core-it-suite/src/test/resources/mng-5840-relative-path-range-positive/child/pom.xml
@@ -17,7 +17,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.4</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <inherited>false</inherited>

--- a/core-it-suite/src/test/resources/mng-5840-relative-path-reactor-matching/child/pom.xml
+++ b/core-it-suite/src/test/resources/mng-5840-relative-path-reactor-matching/child/pom.xml
@@ -17,7 +17,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.4</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <inherited>false</inherited>


### PR DESCRIPTION
To IT test maven3/4 we should not use lower than
3.x plugin (that is maven2 compat)