### PR TITLE
Fix for MavenITmng6656BuildConsumer

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
@@ -23,7 +23,6 @@ import org.apache.maven.it.util.ResourceExtractor;
 import org.apache.maven.shared.utils.io.FileUtils;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
@@ -73,25 +73,25 @@ public class MavenITmng6656BuildConsumer
         verifier.setAutoclean( false );
         verifier.addCliOption( "-Dchangelist=MNG6656" );
 
-        verifier.executeGoals( Collections.singletonList("install") );
+        verifier.executeGoals( Collections.singletonList( "install" ) );
         verifier.verifyErrorFreeLog();
 
-        List<String> generated;
         List<String> expected;
-        generated = FileUtils.loadFile( new File( testDir, "expected/parent.pom") );
-        expected = FileUtils.loadFile( new File( verifier.getArtifactPath( "org.sonatype.mavenbook.multi", "parent", "0.9-MNG6656-SNAPSHOT", "pom" ) ) );
+        List<String> generated;
+        expected = FileUtils.loadFile( new File( testDir, "expected/parent.pom") );
+        generated = FileUtils.loadFile( new File( verifier.getArtifactPath( "org.sonatype.mavenbook.multi", "parent", "0.9-MNG6656-SNAPSHOT", "pom" ) ) );
         assertEquals( expected, generated );
 
-        generated = FileUtils.loadFile( new File( testDir, "expected/simple-parent.pom") );
-        expected = FileUtils.loadFile( new File( verifier.getArtifactPath( "org.sonatype.mavenbook.multi", "simple-parent", "0.9-MNG6656-SNAPSHOT", "pom" ) ) );
+        expected = FileUtils.loadFile( new File( testDir, "expected/simple-parent.pom") );
+        generated = FileUtils.loadFile( new File( verifier.getArtifactPath( "org.sonatype.mavenbook.multi", "simple-parent", "0.9-MNG6656-SNAPSHOT", "pom" ) ) );
         assertEquals( expected, generated );
 
-        generated = FileUtils.loadFile( new File( testDir, "expected/simple-weather.pom") );
-        expected = FileUtils.loadFile( new File( verifier.getArtifactPath( "org.sonatype.mavenbook.multi", "simple-weather", "0.9-MNG6656-SNAPSHOT", "pom" ) ) );
+        expected = FileUtils.loadFile( new File( testDir, "expected/simple-weather.pom") );
+        generated = FileUtils.loadFile( new File( verifier.getArtifactPath( "org.sonatype.mavenbook.multi", "simple-weather", "0.9-MNG6656-SNAPSHOT", "pom" ) ) );
         assertEquals( expected, generated );
 
-        generated = FileUtils.loadFile( new File( testDir, "expected/simple-webapp.pom") );
-        expected = FileUtils.loadFile( new File( verifier.getArtifactPath( "org.sonatype.mavenbook.multi", "simple-webapp", "0.9-MNG6656-SNAPSHOT", "pom" ) ) );
+        expected = FileUtils.loadFile( new File( testDir, "expected/simple-webapp.pom") );
+        generated = FileUtils.loadFile( new File( verifier.getArtifactPath( "org.sonatype.mavenbook.multi", "simple-webapp", "0.9-MNG6656-SNAPSHOT", "pom" ) ) );
         assertEquals( expected, generated );
     }
 

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
@@ -24,6 +24,8 @@ import org.apache.maven.shared.utils.io.FileUtils;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * With the build-consumer the pom.xml will be adjusted during the process.
@@ -71,21 +73,26 @@ public class MavenITmng6656BuildConsumer
         verifier.setAutoclean( false );
         verifier.addCliOption( "-Dchangelist=MNG6656" );
 
-        verifier.executeGoals( Arrays.asList( "install" ) );
+        verifier.executeGoals( Collections.singletonList("install") );
         verifier.verifyErrorFreeLog();
 
-        String content;
-        content = FileUtils.fileRead( new File( testDir, "expected/parent.pom") );
-        verifier.assertArtifactContents( "org.sonatype.mavenbook.multi", "parent", "0.9-MNG6656-SNAPSHOT", "pom", content );
+        List<String> generated;
+        List<String> expected;
+        generated = FileUtils.loadFile( new File( testDir, "expected/parent.pom") );
+        expected = FileUtils.loadFile( new File( verifier.getArtifactPath( "org.sonatype.mavenbook.multi", "parent", "0.9-MNG6656-SNAPSHOT", "pom" ) ) );
+        assertEquals( expected, generated );
 
-        content = FileUtils.fileRead( new File( testDir, "expected/simple-parent.pom") );
-        verifier.assertArtifactContents( "org.sonatype.mavenbook.multi", "simple-parent", "0.9-MNG6656-SNAPSHOT", "pom", content );
+        generated = FileUtils.loadFile( new File( testDir, "expected/simple-parent.pom") );
+        expected = FileUtils.loadFile( new File( verifier.getArtifactPath( "org.sonatype.mavenbook.multi", "simple-parent", "0.9-MNG6656-SNAPSHOT", "pom" ) ) );
+        assertEquals( expected, generated );
 
-        content = FileUtils.fileRead( new File( testDir, "expected/simple-weather.pom") );
-        verifier.assertArtifactContents( "org.sonatype.mavenbook.multi", "simple-weather", "0.9-MNG6656-SNAPSHOT", "pom", content );
+        generated = FileUtils.loadFile( new File( testDir, "expected/simple-weather.pom") );
+        expected = FileUtils.loadFile( new File( verifier.getArtifactPath( "org.sonatype.mavenbook.multi", "simple-weather", "0.9-MNG6656-SNAPSHOT", "pom" ) ) );
+        assertEquals( expected, generated );
 
-        content = FileUtils.fileRead( new File( testDir, "expected/simple-webapp.pom") );
-        verifier.assertArtifactContents( "org.sonatype.mavenbook.multi", "simple-webapp", "0.9-MNG6656-SNAPSHOT", "pom", content );
+        generated = FileUtils.loadFile( new File( testDir, "expected/simple-webapp.pom") );
+        expected = FileUtils.loadFile( new File( verifier.getArtifactPath( "org.sonatype.mavenbook.multi", "simple-webapp", "0.9-MNG6656-SNAPSHOT", "pom" ) ) );
+        assertEquals( expected, generated );
     }
 
 }


### PR DESCRIPTION
Instead to compare POMs as "string blobs" (so along with all line-ending),
it should go for pure content instead, as it makes IT more
resilient to environment related issues.