### PR TITLE
[MNG-6762] Test whether a settings.xml file can be referenced relatively to the .mvn directory instead of working directory

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/IntegrationTestSuite.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/IntegrationTestSuite.java
@@ -106,6 +106,7 @@ public class IntegrationTestSuite
         // Tests that don't run stable and need to be fixed
         // -------------------------------------------------------------------------------------------------------------
         // suite.addTestSuite( MavenIT0108SnapshotUpdateTest.class ); -- MNG-3137
+        suite.addTestSuite( MavenITmng6762MultiModuleRelativeSettings.class );
         suite.addTestSuite( MavenITmng4463DependencyManagementImportVersionRanges.class );
         suite.addTestSuite( MavenITmng7112ProjectsWithNonRecursiveTest.class );
         suite.addTestSuite( MavenITmng7128BlockExternalHttpReactorTest.class );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6762MultiModuleRelativeSettings.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6762MultiModuleRelativeSettings.java
@@ -1,0 +1,67 @@
+package org.apache.maven.it;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.it.util.ResourceExtractor;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Testing whether a .mvn/maven.config file can relatively reference a .mvn/settings.xml file.
+ */
+public class MavenITmng6762MultiModuleRelativeSettings extends AbstractMavenIntegrationTestCase
+{
+    private static final String SETTINGS_RESOURCE_PATH = "/mng-6762-multi-module-relative-settings";
+    private final File testDir;
+
+    public MavenITmng6762MultiModuleRelativeSettings() throws IOException
+    {
+        super( "[4.0.0-alpha-1,)" );
+        testDir = ResourceExtractor.simpleExtractResources( getClass(), SETTINGS_RESOURCE_PATH );
+    }
+
+    /**
+     * This test verifies whether an invocation from root resolves .mvn/settings.xml correctly.
+     */
+    public void testInRoot() throws VerificationException
+    {
+        Verifier verifier = newVerifier( testDir.getAbsolutePath() );
+        verifier.setLogFileName( "log-inroot.txt" );
+
+        verifier.executeGoal( "validate" );
+
+        verifier.assertFilePresent( "target/profile-activated.txt" );
+    }
+
+    /**
+     * This test verifies whether an invocation from a submodule resolves ../.mvn/settings.xml correctly.
+     */
+    public void testInSubModule() throws VerificationException
+    {
+        final File submoduleDirectory = new File( testDir, "submodule" );
+        Verifier verifier = newVerifier( submoduleDirectory.getAbsolutePath() );
+        verifier.setLogFileName( "log-insubmodule.txt" );
+
+        verifier.executeGoal( "validate" );
+
+        verifier.assertFilePresent( "target/profile-activated.txt" );
+    }
+}

--- a/core-it-suite/src/test/resources/mng-6762-multi-module-relative-settings/.mvn/maven.config
+++ b/core-it-suite/src/test/resources/mng-6762-multi-module-relative-settings/.mvn/maven.config
@@ -1,0 +1,1 @@
+-s=.mvn/settings.xml

--- a/core-it-suite/src/test/resources/mng-6762-multi-module-relative-settings/.mvn/settings.xml
+++ b/core-it-suite/src/test/resources/mng-6762-multi-module-relative-settings/.mvn/settings.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
+  <activeProfiles>
+      <activeProfile>integration-test-profile-from-settings</activeProfile>
+  </activeProfiles>
+</settings>

--- a/core-it-suite/src/test/resources/mng-6762-multi-module-relative-settings/pom.xml
+++ b/core-it-suite/src/test/resources/mng-6762-multi-module-relative-settings/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.its.mng6762</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0</version>
+
+    <packaging>pom</packaging>
+
+    <name>Maven Integration Test :: MNG-6762</name>
+    <description>
+        Tests for resolving a .mvn/settings.xml file from within root and a submodule.
+    </description>
+
+    <modules>
+        <module>submodule</module>
+    </modules>
+
+    <profiles>
+        <profile>
+            <id>integration-test-profile-from-settings</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.its.plugins</groupId>
+                        <artifactId>maven-it-plugin-ant-based</artifactId>
+                        <version>2.1-SNAPSHOT</version>
+                        <configuration>
+                            <outputFile>target/profile-activated.txt</outputFile>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>test</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>touch</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/core-it-suite/src/test/resources/mng-6762-multi-module-relative-settings/submodule/pom.xml
+++ b/core-it-suite/src/test/resources/mng-6762-multi-module-relative-settings/submodule/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>parent</artifactId>
+        <groupId>org.apache.its.mng6762</groupId>
+        <version>1.0</version>
+    </parent>
+
+    <artifactId>submodule</artifactId>
+    <name>Maven Integration Test :: MNG-6762 :: Submodule</name>
+</project>


### PR DESCRIPTION
Before, when a settings.xml file was referenced in maven.config, it was resolved against the working directory, which would break when maven is invoked in a submodule. This PR changes it to resolve against the multi module root.

Maven-core PR: https://github.com/apache/maven/pull/566