### PR TITLE
[MNG-7332] Remove --define (long arg)

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4410UsageHelpTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4410UsageHelpTest.java
@@ -53,7 +53,6 @@ public class MavenITmng4410UsageHelpTest
         verifier.resetStreams();
 
         verifier.verifyTextInLog( "--version" );
-        verifier.verifyTextInLog( "--define" );
         verifier.verifyTextInLog( "--debug" );
         verifier.verifyTextInLog( "--batch-mode" );
     }


### PR DESCRIPTION
Removes the one occurrence of `--define` in our integration test suite.
It is a case where we verify the output of `mvn --help`.
Apparently, in all other cases, we use `-D` already.