### PR TITLE
Set Maven compiler and release versions to 7 for integration test projects

### DIFF
--- a/core-it-suite/src/test/resources/mng-4660-outdated-packaged-artifact/pom.xml
+++ b/core-it-suite/src/test/resources/mng-4660-outdated-packaged-artifact/pom.xml
@@ -38,8 +38,8 @@ under the License.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
 
     <modules>

--- a/core-it-suite/src/test/resources/mng-4660-resume-from/pom.xml
+++ b/core-it-suite/src/test/resources/mng-4660-resume-from/pom.xml
@@ -38,8 +38,8 @@ under the License.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
 
     <modules>

--- a/core-it-suite/src/test/resources/mng-5760-resume-feature/four-modules/pom.xml
+++ b/core-it-suite/src/test/resources/mng-5760-resume-feature/four-modules/pom.xml
@@ -37,8 +37,8 @@ under the License.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
 
     <modules>

--- a/core-it-suite/src/test/resources/mng-5760-resume-feature/parent-dependent/pom.xml
+++ b/core-it-suite/src/test/resources/mng-5760-resume-feature/parent-dependent/pom.xml
@@ -37,8 +37,8 @@ under the License.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
 
     <modules>

--- a/core-it-suite/src/test/resources/mng-5760-resume-feature/parent-independent/pom.xml
+++ b/core-it-suite/src/test/resources/mng-5760-resume-feature/parent-independent/pom.xml
@@ -37,8 +37,8 @@ under the License.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
 
     <modules>

--- a/core-it-suite/src/test/resources/mng-6118-submodule-invocation-full-reactor/pom.xml
+++ b/core-it-suite/src/test/resources/mng-6118-submodule-invocation-full-reactor/pom.xml
@@ -37,8 +37,8 @@ under the License.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
   </properties>
 
   <modules>

--- a/core-it-suite/src/test/resources/mng-6511-optional-project-selection/pom.xml
+++ b/core-it-suite/src/test/resources/mng-6511-optional-project-selection/pom.xml
@@ -37,8 +37,8 @@ under the License.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
   </properties>
 
   <modules>

--- a/core-it-suite/src/test/resources/mng-6972-allow-access-to-graph-package/build-plugin/pom.xml
+++ b/core-it-suite/src/test/resources/mng-6972-allow-access-to-graph-package/build-plugin/pom.xml
@@ -28,8 +28,8 @@ under the License.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
 
     <plexus-component.version>1.5.5</plexus-component.version>
     <maven-version>3.3.1</maven-version>

--- a/core-it-suite/src/test/resources/mng-6981-pl-should-include-children/pom.xml
+++ b/core-it-suite/src/test/resources/mng-6981-pl-should-include-children/pom.xml
@@ -37,8 +37,8 @@ under the License.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
 
     <modules>

--- a/core-it-suite/src/test/resources/mng-7045/pom.xml
+++ b/core-it-suite/src/test/resources/mng-7045/pom.xml
@@ -25,8 +25,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>8</source>
-          <target>8</target>
+          <source>1.7</source>
+          <target>1.7</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>

--- a/core-it-suite/src/test/resources/mng-7128-block-external-http-reactor/pom.xml
+++ b/core-it-suite/src/test/resources/mng-7128-block-external-http-reactor/pom.xml
@@ -25,8 +25,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>8</source>
-          <target>8</target>
+          <source>1.7</source>
+          <target>1.7</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>


### PR DESCRIPTION
See discussion here: https://github.com/apache/maven-integration-testing/pull/135#discussion_r787104645. 