### PR TITLE
[MNG-7470] Quarkus build

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/IntegrationTestSuite.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/IntegrationTestSuite.java
@@ -106,6 +106,7 @@ public class IntegrationTestSuite
         // Tests that don't run stable and need to be fixed
         // -------------------------------------------------------------------------------------------------------------
         // suite.addTestSuite( MavenIT0108SnapshotUpdateTest.class ); -- MNG-3137
+        suite.addTestSuite( MavenITmng7470QuarkusTest.class );
         suite.addTestSuite( MavenITmng7404IgnorePrefixlessExpressionsTest.class );
         suite.addTestSuite( MavenITmng5222MojoDeprecatedTest.class );
         suite.addTestSuite( MavenITmng7390SelectModuleOutsideCwdTest.class );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7470QuarkusTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7470QuarkusTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.maven.it.util.ResourceExtractor;
+
+public class MavenITmng7470QuarkusTest extends AbstractMavenIntegrationTestCase
+{
+    private static final String PROJECT_PATH = "/mng-7470-quarkus";
+
+    public MavenITmng7470QuarkusTest()
+    {
+        super( "[3.8.0,)" );
+    }
+
+    public void testBuildUsingQuarkusPlugin() throws IOException, VerificationException
+    {
+        final File projectDir = ResourceExtractor.simpleExtractResources( getClass(), PROJECT_PATH );
+        final Verifier verifier = newVerifier( projectDir.getAbsolutePath() );
+
+        verifier.executeGoal( "verify" );
+        verifier.verifyErrorFreeLog();
+    }
+}

--- a/core-it-suite/src/test/resources/mng-7470-quarkus/pom.xml
+++ b/core-it-suite/src/test/resources/mng-7470-quarkus/pom.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2021 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.mvndaemon.mvnd.test.type-description</groupId>
+    <artifactId>type-description</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>server</module>
+    </modules>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
+        <timestamp>${maven.build.timestamp}</timestamp>
+
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
+        <docker.tag.name>latest-release</docker.tag.name>
+        <tar.long.file.mode>gnu</tar.long.file.mode>
+        
+        <!-- Quarkus Version -->
+        <quarkus.version>2.3.1.Final</quarkus.version>
+
+        <!-- Jandex -->
+        <jandex.version>1.0.8</jandex.version>
+
+        <!-- Plugin Versions -->
+        <version.compiler.plugin>3.8.1</version.compiler.plugin>
+        <version.surefire.plugin>2.22.2</version.surefire.plugin>
+        <version.dependency.plugin>3.1.2</version.dependency.plugin>
+        <version.assembly.plugin>3.3.0</version.assembly.plugin>
+        <version.resources.plugin>3.2.0</version.resources.plugin>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- This project -->
+
+            <!-- Quarkus Dependencies -->
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${version.compiler.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${version.surefire.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jboss.jandex</groupId>
+                    <artifactId>jandex-maven-plugin</artifactId>
+                    <version>${jandex.version}</version>
+                    <executions>
+                        <execution>
+                            <id>make-index</id>
+                            <goals>
+                                <goal>jandex</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>${quarkus.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${maven.compiler.target}</source>
+                    <target>${maven.compiler.target}</target>
+                    <showDeprecation>false</showDeprecation>
+                    <showWarnings>false</showWarnings>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${version.dependency.plugin}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${version.assembly.plugin}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${version.resources.plugin}</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+

--- a/core-it-suite/src/test/resources/mng-7470-quarkus/server/pom.xml
+++ b/core-it-suite/src/test/resources/mng-7470-quarkus/server/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright 2021 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.mvndaemon.mvnd.test.type-description</groupId>
+        <artifactId>type-description</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>mvnd-server</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <!-- Quarkus Dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-undertow</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-agroal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.quarkus</groupId>
+                        <artifactId>quarkus-maven-plugin</artifactId>
+                        <version>${quarkus.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                                <configuration>
+                                    <enableHttpUrlHandler>false</enableHttpUrlHandler>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>
+

--- a/core-it-suite/src/test/resources/mng-7470-quarkus/server/src/main/java/org/mvndaemon/mvnd/test/type/description/server/Main.java
+++ b/core-it-suite/src/test/resources/mng-7470-quarkus/server/src/main/java/org/mvndaemon/mvnd/test/type/description/server/Main.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvndaemon.mvnd.test.type.description.server;
+
+import io.quarkus.runtime.Quarkus;
+
+/**
+ * @author Ales Justin
+ */
+public class Main {
+    public static void main(String[] args) {
+        Quarkus.run(args);
+    }
+}

--- a/core-it-suite/src/test/resources/mng-7470-quarkus/server/src/main/java/org/mvndaemon/mvnd/test/type/description/server/domain/AbstractEntity.java
+++ b/core-it-suite/src/test/resources/mng-7470-quarkus/server/src/main/java/org/mvndaemon/mvnd/test/type/description/server/domain/AbstractEntity.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvndaemon.mvnd.test.type.description.server.domain;
+
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+import java.io.Serializable;
+
+/**
+ * @author Ales Justin
+ */
+@MappedSuperclass
+public abstract class AbstractEntity implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+}

--- a/core-it-suite/src/test/resources/mng-7470-quarkus/server/src/main/java/org/mvndaemon/mvnd/test/type/description/server/domain/Image.java
+++ b/core-it-suite/src/test/resources/mng-7470-quarkus/server/src/main/java/org/mvndaemon/mvnd/test/type/description/server/domain/Image.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvndaemon.mvnd.test.type.description.server.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Lob;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import javax.sql.rowset.serial.SerialBlob;
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.Blob;
+import java.sql.SQLException;
+
+/**
+ * @author Ales Justin
+ */
+@Entity
+@Table(
+        name = Image.TABLE_NAME,
+        uniqueConstraints = @UniqueConstraint(name = Image.PK_CONSTRAINT_NAME, columnNames = {"name"})
+)
+public class Image extends AbstractEntity {
+    public static final String TABLE_NAME = "image";
+    public static final String PK_CONSTRAINT_NAME = TABLE_NAME + "_pkey";
+
+    @Column(nullable = false)
+    private String name;
+    @Lob
+    private Blob blob;
+    private String mimeType;
+    private long length;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    public void setMimeType(String mimeType) {
+        this.mimeType = mimeType;
+    }
+
+    public long getLength() {
+        return length;
+    }
+
+    public void setLength(long length) {
+        this.length = length;
+    }
+
+    public Blob getBlob() {
+        return blob;
+    }
+
+    public void setBlob(Blob blob) {
+        this.blob = blob;
+    }
+
+    public void write(byte[] bytes) throws Exception {
+        blob = new SerialBlob(bytes);
+    }
+
+    public byte[] read() throws IOException {
+        if (blob == null)
+            return null;
+
+        try {
+            return blob.getBytes(1, (int) blob.length() + 1);
+        } catch (SQLException e) {
+            throw new IOException(e.getMessage(), e);
+        }
+    }
+
+    public InputStream stream() throws IOException {
+        try {
+            return (blob != null) ? blob.getBinaryStream() : null;
+        } catch (SQLException e) {
+            throw new IOException(e.getMessage(), e);
+        }
+    }
+}

--- a/core-it-suite/src/test/resources/mng-7470-quarkus/server/src/main/resources/application.properties
+++ b/core-it-suite/src/test/resources/mng-7470-quarkus/server/src/main/resources/application.properties
@@ -1,0 +1,24 @@
+#
+# Copyright 2021 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:file:/tmp/h2/database.db;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+quarkus.datasource.jdbc.driver=org.h2.Driver
+quarkus.datasource.username=sa
+quarkus.datasource.password=sa
+quarkus.datasource.jdbc.max-size=10
+quarkus.hibernate-orm.database.generation=create-drop
+quarkus.hibernate-orm.log.sql=true

--- a/core-it-suite/src/test/resources/mng-7470-quarkus/server/src/main/resources/log4j.properties
+++ b/core-it-suite/src/test/resources/mng-7470-quarkus/server/src/main/resources/log4j.properties
@@ -1,0 +1,21 @@
+#
+# Copyright 2021 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.rootLogger=INFO, consoleAppender
+
+log4j.appender.consoleAppender=org.apache.log4j.ConsoleAppender
+log4j.appender.consoleAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.consoleAppender.layout.ConversionPattern=[%t] %-5p %c %x - %m%n


### PR DESCRIPTION
A build "borrowed" as is from mvnd build that uses
quarkus plugin, a notorius one for using resolver.

Currently:
* passes OK with maven 3.8.x
* FAILS with naven 3.9.0-SNAPSHOT (when downloads happens, when running ITs with prepopulated local repo it will pass OK)