### PR TITLE
Fix the MavenITmng7470ResolverTransportTest

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7470ResolverTransportTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7470ResolverTransportTest.java
@@ -58,6 +58,8 @@ public class MavenITmng7470ResolverTransportTest
     private void performTest( /* nullable */ final String transport, final String logSnippet ) throws Exception
     {
         Verifier verifier = newVerifier( projectDir.getAbsolutePath() );
+        verifier.setForkJvm( true );
+
         Map<String, String> properties = new HashMap<>();
         properties.put( "@port@", Integer.toString( port ) );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", properties );


### PR DESCRIPTION
Seems the test must be forked to work in, as it fails to work
in embedded mode.