### PR TITLE
Fix - mute Jetty

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/HttpServer.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/HttpServer.java
@@ -12,6 +12,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
 import org.eclipse.jetty.util.log.StdErrLog;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Password;
@@ -40,7 +41,11 @@ public class HttpServer
 {
     static {
         Log.initialized();
-        ((StdErrLog) Log.getRootLogger()).setLevel( StdErrLog.LEVEL_WARN );
+        Logger rootLogger = Log.getRootLogger();
+        if ( rootLogger instanceof StdErrLog )
+        {
+            ( (StdErrLog) rootLogger ).setLevel( StdErrLog.LEVEL_WARN );
+        }
     }
 
     private final Server server;


### PR DESCRIPTION
Fix for #159

Jetty logger not always is `StdErrLog` can be eg. `Slf4jLog`