### PR TITLE
Relax test for wider terminals

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6391PrintVersionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6391PrintVersionTest.java
@@ -74,11 +74,10 @@ public class MavenITmng6391PrintVersionTest
 
         // We expect those lines in the following exact order.
         assertTrue( resultingLines.get( 0 ).startsWith( "[INFO] Reactor Summary for base-project 1.3.0-SNAPSHOT:" ) );
-        assertTrue( resultingLines.get( 1 ).startsWith( "[INFO] base-project ....................................... SUCCESS [" ) );
-        assertTrue( resultingLines.get( 2 ).startsWith( "[INFO] module-1 ........................................... SUCCESS [" ) );
-        assertTrue( resultingLines.get( 3 ).startsWith( "[INFO] module-2 ........................................... SUCCESS [" ) );
-        assertTrue( resultingLines.get( 4 ).startsWith( "[INFO] module-3 ........................................... SUCCESS [" ) );
-
+        assertTrue( resultingLines.get( 1 ).matches( "\\Q[INFO] base-project ............\\E\\.+\\Q SUCCESS [\\E.*" ) );
+        assertTrue( resultingLines.get( 2 ).matches( "\\Q[INFO] module-1 ................\\E\\.+\\Q SUCCESS [\\E.*" ) );
+        assertTrue( resultingLines.get( 3 ).matches( "\\Q[INFO] module-2 ................\\E\\.+\\Q SUCCESS [\\E.*" ) );
+        assertTrue( resultingLines.get( 4 ).matches( "\\Q[INFO] module-3 ................\\E\\.+\\Q SUCCESS [\\E.*" ) );
     }
 
     /**
@@ -110,10 +109,10 @@ public class MavenITmng6391PrintVersionTest
 
         // We expect those lines in the following exact order.
         assertTrue( resultingLines.get( 0 ).startsWith( "[INFO] Reactor Summary:" ) );
-        assertTrue( resultingLines.get( 1 ).startsWith( "[INFO] module-1 1.2.7.43.RELEASE .......................... SUCCESS [  " ) );
-        assertTrue( resultingLines.get( 2 ).startsWith( "[INFO] module-2 7.5-SNAPSHOT .............................. SUCCESS [  " ) );
-        assertTrue( resultingLines.get( 3 ).startsWith( "[INFO] module-3 1-RC1 ..................................... SUCCESS [  " ) );
-        assertTrue( resultingLines.get( 4 ).startsWith( "[INFO] base-project 1.0.0-SNAPSHOT ........................ SUCCESS [  " ) );
+        assertTrue( resultingLines.get( 1 ).matches( "\\Q[INFO] module-1 1.2.7.43.RELEASE ...............\\E\\.+\\Q SUCCESS [ \\E.*" ) );
+        assertTrue( resultingLines.get( 2 ).matches( "\\Q[INFO] module-2 7.5-SNAPSHOT ...................\\E\\.+\\Q SUCCESS [ \\E.*" ) );
+        assertTrue( resultingLines.get( 3 ).matches( "\\Q[INFO] module-3 1-RC1 ..........................\\E\\.+\\Q SUCCESS [ \\E.*" ) );
+        assertTrue( resultingLines.get( 4 ).matches( "\\Q[INFO] base-project 1.0.0-SNAPSHOT .............\\E\\.+\\Q SUCCESS [ \\E.*" ) );
 
     }
 


### PR DESCRIPTION
Maven 4.0.x has some code new code which takes care of the terminal width to adjust the output.  The number of dots can thus vary when running the tests locally.