### PR TITLE
[MNG-7517] Improve MavenITmng6391PrintVersionTest tests resiliency

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6391PrintVersionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6391PrintVersionTest.java
@@ -73,11 +73,19 @@ public class MavenITmng6391PrintVersionTest
         assertEquals( 5, resultingLines.size() );
 
         // We expect those lines in the following exact order.
+        // Maven 4.0.x has some code new code which takes care of the terminal width to adjust the output.
+        // The number of dots can thus vary when running the tests.
         assertTrue( resultingLines.get( 0 ).startsWith( "[INFO] Reactor Summary for base-project 1.3.0-SNAPSHOT:" ) );
-        assertTrue( resultingLines.get( 1 ).startsWith( "[INFO] base-project ....................................... SUCCESS [" ) );
-        assertTrue( resultingLines.get( 2 ).startsWith( "[INFO] module-1 ........................................... SUCCESS [" ) );
-        assertTrue( resultingLines.get( 3 ).startsWith( "[INFO] module-2 ........................................... SUCCESS [" ) );
-        assertTrue( resultingLines.get( 4 ).startsWith( "[INFO] module-3 ........................................... SUCCESS [" ) );
+        assertTrue( resultingLines.get( 1 ).matches( "\\Q[INFO] base-project ............\\E\\.+\\Q SUCCESS [\\E.*" ) );
+        assertTrue( resultingLines.get( 2 ).matches( "\\Q[INFO] module-1 ................\\E\\.+\\Q SUCCESS [\\E.*" ) );
+        assertTrue( resultingLines.get( 3 ).matches( "\\Q[INFO] module-2 ................\\E\\.+\\Q SUCCESS [\\E.*" ) );
+        assertTrue( resultingLines.get( 4 ).matches( "\\Q[INFO] module-3 ................\\E\\.+\\Q SUCCESS [\\E.*" ) );
+
+        // We expect that line 1..4 have the same length
+        int line1Length = resultingLines.get( 1 ).length();
+        assertEquals( line1Length, resultingLines.get( 2 ).length() );
+        assertEquals( line1Length, resultingLines.get( 3 ).length() );
+        assertEquals( line1Length, resultingLines.get( 4 ).length() );
 
     }
 
@@ -109,11 +117,19 @@ public class MavenITmng6391PrintVersionTest
         assertEquals( 5, resultingLines.size() );
 
         // We expect those lines in the following exact order.
+        // Maven 4.0.x has some code new code which takes care of the terminal width to adjust the output.
+        // The number of dots can thus vary when running the tests.
         assertTrue( resultingLines.get( 0 ).startsWith( "[INFO] Reactor Summary:" ) );
-        assertTrue( resultingLines.get( 1 ).startsWith( "[INFO] module-1 1.2.7.43.RELEASE .......................... SUCCESS [  " ) );
-        assertTrue( resultingLines.get( 2 ).startsWith( "[INFO] module-2 7.5-SNAPSHOT .............................. SUCCESS [  " ) );
-        assertTrue( resultingLines.get( 3 ).startsWith( "[INFO] module-3 1-RC1 ..................................... SUCCESS [  " ) );
-        assertTrue( resultingLines.get( 4 ).startsWith( "[INFO] base-project 1.0.0-SNAPSHOT ........................ SUCCESS [  " ) );
+        assertTrue( resultingLines.get( 1 ).matches( "\\Q[INFO] module-1 1.2.7.43.RELEASE ...............\\E\\.+\\Q SUCCESS [ \\E.*" ) );
+        assertTrue( resultingLines.get( 2 ).matches( "\\Q[INFO] module-2 7.5-SNAPSHOT ...................\\E\\.+\\Q SUCCESS [ \\E.*" ) );
+        assertTrue( resultingLines.get( 3 ).matches( "\\Q[INFO] module-3 1-RC1 ..........................\\E\\.+\\Q SUCCESS [ \\E.*" ) );
+        assertTrue( resultingLines.get( 4 ).matches( "\\Q[INFO] base-project 1.0.0-SNAPSHOT .............\\E\\.+\\Q SUCCESS [ \\E.*" ) );
+
+        // We expect that line 1..4 have the same length
+        int line1Length = resultingLines.get( 1 ).length();
+        assertEquals( line1Length, resultingLines.get( 2 ).length() );
+        assertEquals( line1Length, resultingLines.get( 3 ).length() );
+        assertEquals( line1Length, resultingLines.get( 4 ).length() );
 
     }
 


### PR DESCRIPTION
Depending on the test environment, the number of dots displayed by Maven in the 'Reactor Summary' may vary. Regexes have to be used to take that into account.