### PR TITLE
Fix flappy test - mng-6720-fail-fast

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6720FailFastTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6720FailFastTest.java
@@ -19,14 +19,12 @@ package org.apache.maven.it;
  * under the License.
  */
 
-import org.apache.maven.shared.verifier.util.ResourceExtractor;
-import org.apache.maven.shared.verifier.Verifier;
-import org.apache.maven.shared.verifier.VerificationException;
-
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
 
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.shared.verifier.Verifier;
+import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -36,7 +34,7 @@ import org.junit.jupiter.api.Test;
  * <a href="https://issues.apache.org/jira/browse/MNG-6720">MNG-6720</a>.
  *
  */
-public class MavenITmng6720FailFastTest
+class MavenITmng6720FailFastTest
     extends AbstractMavenIntegrationTestCase
 {
 
@@ -46,35 +44,34 @@ public class MavenITmng6720FailFastTest
     }
 
     @Test
-    public void testItShouldWaitForConcurrentModulesToFinish()
+    void testItShouldWaitForConcurrentModulesToFinish()
         throws Exception
     {
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-6720-fail-fast" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath(), false );
-        verifier.setMavenDebug( false );
         verifier.setAutoclean( false );
-        verifier.addCliOption( "-T" );
-        verifier.addCliOption( "2" );
-        verifier.addCliOption( "-Dmaven.test.redirectTestOutputToFile=true" );
+        verifier.addCliArguments( "-T", "2" );
+        verifier.addCliArgument( "-Dmaven.test.redirectTestOutputToFile=true" );
+        verifier.addCliArguments( "clean", "test" );
 
         try
         {
-            verifier.executeGoals( Arrays.asList( "clean", "test" ) );
-        } catch ( VerificationException e )
+            verifier.execute();
+        }
+        catch ( VerificationException e)
         {
             //expected
         }
-        verifier.resetStreams();
 
         List<String> module1Lines = verifier.loadFile(
             new File( testDir, "module-1/target/surefire-reports/Module1Test-output.txt" ), false );
-        assertTrue( module1Lines.contains( "Module1" ) );
+        assertTrue( "module-1 should be executed", module1Lines.contains( "Module1" ) );
         List<String> module2Lines = verifier.loadFile(
             new File( testDir, "module-2/target/surefire-reports/Module2Test-output.txt" ), false );
-        assertTrue(module2Lines.contains( "Module2" ) );
+        assertTrue("module-2 should be executed", module2Lines.contains( "Module2" ) );
         List<String> module3Lines = verifier.loadFile(
             new File( testDir, "module-3/target/surefire-reports/Module3Test-output.txt" ), false );
-        assertTrue( module3Lines.isEmpty() );
+        assertTrue( "module-3 should be skipped", module3Lines.isEmpty() );
     }
 }

--- a/core-it-suite/src/test/resources-filtered/bootstrap.txt
+++ b/core-it-suite/src/test/resources-filtered/bootstrap.txt
@@ -103,6 +103,7 @@ org.apache.maven.plugins:maven-resources-plugin:${stubPluginVersion}
 org.apache.maven.plugins:maven-resources-plugin:2.6
 org.apache.maven.plugins:maven-resources-plugin:2.7
 org.apache.maven.plugins:maven-resources-plugin:3.2.0
+org.apache.maven.plugins:maven-resources-plugin:3.3.0
 org.apache.maven.plugins:maven-site-plugin:${stubPluginVersion}
 org.apache.maven.plugins:maven-site-plugin:3.2
 org.apache.maven.plugins:maven-site-plugin:3.3

--- a/core-it-suite/src/test/resources/mng-6720-fail-fast/module-1/pom.xml
+++ b/core-it-suite/src/test/resources/mng-6720-fail-fast/module-1/pom.xml
@@ -37,13 +37,20 @@
   </dependencies>
 
   <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.0</version>
-      </plugin>
-    </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
 </project>

--- a/core-it-suite/src/test/resources/mng-6720-fail-fast/module-2/pom.xml
+++ b/core-it-suite/src/test/resources/mng-6720-fail-fast/module-2/pom.xml
@@ -37,13 +37,20 @@
   </dependencies>
 
   <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.0</version>
-      </plugin>
-    </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
 </project>

--- a/core-it-suite/src/test/resources/mng-6720-fail-fast/module-3/pom.xml
+++ b/core-it-suite/src/test/resources/mng-6720-fail-fast/module-3/pom.xml
@@ -42,13 +42,20 @@
   </dependencies>
 
   <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.0</version>
-      </plugin>
-    </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
 </project>

--- a/core-it-suite/src/test/resources/mng-6720-fail-fast/pom.xml
+++ b/core-it-suite/src/test/resources/mng-6720-fail-fast/pom.xml
@@ -35,15 +35,4 @@ under the License.
     <module>module-3</module>
   </modules>
 
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-resources-plugin</artifactId>
-          <version>3.2.0</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 </project>


### PR DESCRIPTION
- old m-resource-p can fail in multi thread executions
- test project use aggregation - so we need provided configuration in each module
- replace deprecated method
- add message for assertions