### PR TITLE
Update actions in GH build

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -19,8 +19,15 @@ name: Java CI
 
 on: [push, pull_request]
 
+# clear all permissions for GITHUB_TOKEN
+permissions: {}
+
 jobs:
   build:
+
+    # execute on any push or pull request from forked repo
+    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork )
+
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -30,10 +37,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -43,6 +52,4 @@ jobs:
         run: mvn --errors --batch-mode --show-version wrapper:wrapper "-Dmaven=3.8.6"
 
       - name: Running integration tests
-        # execute on any push or pull request from forked repo
-        if: github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork )
         run: "./mvnw -B clean install -Prun-its,embedded -Dmaven.repo.local=`pwd`/repo"


### PR DESCRIPTION
Old actions use deprecated node 12

- checkout v2 -> v3
- setup-java v2 -> v3
- disable access to GITHUB_TOKEN
- don't store credentials with checkout