### PR TITLE
Upgrade Groovy in one of the ITs to support JDK 19

### DIFF
--- a/core-it-suite/src/test/resources-filtered/bootstrap.txt
+++ b/core-it-suite/src/test/resources-filtered/bootstrap.txt
@@ -12,8 +12,8 @@ javax.annotation:javax.annotation-api:1.2
 junit:junit:4.12
 org.apache.ant:ant:1.10.8
 org.apache.geronimo.specs:geronimo-jcdi_2.0_spec:1.3
-org.apache.groovy:groovy-ant:4.0.0-alpha-3
-org.apache.groovy:groovy:4.0.0-alpha-3
+org.apache.groovy:groovy-ant:4.0.6
+org.apache.groovy:groovy:4.0.6
 org.apache.maven.its.plugins.class-loader:dep-c:${project.version}
 org.apache.maven.its.plugins:maven-it-plugin-active-collection:${project.version}
 org.apache.maven.its.plugins:maven-it-plugin-all:${project.version}

--- a/core-it-suite/src/test/resources/mng-7045/pom.xml
+++ b/core-it-suite/src/test/resources/mng-7045/pom.xml
@@ -55,13 +55,13 @@ javax.enterprise.inject.Instance.class.getDeclaredMethod("stream")
           <dependency>
             <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-ant</artifactId>
-            <version>4.0.0-alpha-3</version>
+            <version>4.0.6</version>
             <scope>runtime</scope>
           </dependency>
           <dependency>
             <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
-            <version>4.0.0-alpha-3</version>
+            <version>4.0.6</version>
             <scope>runtime</scope>
           </dependency>
         </dependencies>


### PR DESCRIPTION
This should be the only change needed to run the tests on JDK 19. Tested with Maven 3.8.7 and latest master as of today (4.0.0-alpha-4-SNAPSHOT):
 * `mvn clean install -Prun-its -Dmaven.repo.local=$(pwd)/repo `
 * `mvn clean install -Prun-its -Dmaven.repo.local=$(pwd)/repo -Dmaven.home=<path-to-maven-git-repo>/apache-maven/target/apache-maven-4.0.0-alpha-4-SNAPSHOT`