### PR TITLE
[MNG-7661] Use provided scope for Maven deps in IT plugins

### DIFF
--- a/core-it-support/core-it-plugins/maven-it-plugin-active-collection/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-active-collection/pom.xml
@@ -46,11 +46,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-all/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-all/pom.xml
@@ -43,6 +43,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-artifact/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-artifact/pom.xml
@@ -48,26 +48,31 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-repository-metadata</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-class-loader/maven-it-plugin-class-loader/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-class-loader/maven-it-plugin-class-loader/pom.xml
@@ -44,6 +44,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-configuration/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-configuration/pom.xml
@@ -43,6 +43,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-context-passing/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-context-passing/pom.xml
@@ -43,6 +43,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-clean-plugin/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-clean-plugin/pom.xml
@@ -49,11 +49,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-compiler-plugin/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-compiler-plugin/pom.xml
@@ -49,11 +49,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-deploy-plugin/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-deploy-plugin/pom.xml
@@ -49,11 +49,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-ear-plugin/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-ear-plugin/pom.xml
@@ -49,11 +49,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-ejb-plugin/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-ejb-plugin/pom.xml
@@ -49,11 +49,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-install-plugin/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-install-plugin/pom.xml
@@ -49,11 +49,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-jar-plugin/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-jar-plugin/pom.xml
@@ -49,11 +49,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-javadoc-plugin/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-javadoc-plugin/pom.xml
@@ -49,11 +49,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-plugin-plugin/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-plugin-plugin/pom.xml
@@ -49,11 +49,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-rar-plugin/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-rar-plugin/pom.xml
@@ -49,11 +49,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-resources-plugin/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-resources-plugin/pom.xml
@@ -49,11 +49,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-site-plugin/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-site-plugin/pom.xml
@@ -49,11 +49,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-source-plugin/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-source-plugin/pom.xml
@@ -49,11 +49,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-surefire-plugin/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-surefire-plugin/pom.xml
@@ -49,11 +49,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-war-plugin/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-war-plugin/pom.xml
@@ -49,11 +49,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-dependency-collection/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-dependency-collection/pom.xml
@@ -47,16 +47,19 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-dependency-resolution/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-dependency-resolution/pom.xml
@@ -47,11 +47,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.1.0</version>
+      <scope>provided</scope>
     </dependency>
      <dependency>
       <groupId>org.apache.maven</groupId>
@@ -63,6 +65,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-error/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-error/pom.xml
@@ -47,6 +47,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-expression/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-expression/pom.xml
@@ -43,6 +43,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-extension-consumer/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-extension-consumer/pom.xml
@@ -46,6 +46,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.its</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-extension-provider/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-extension-provider/pom.xml
@@ -47,6 +47,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.its</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-extension1/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-extension1/pom.xml
@@ -45,6 +45,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-extension2/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-extension2/pom.xml
@@ -46,6 +46,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-fork/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-fork/pom.xml
@@ -43,11 +43,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-invalid-descriptor/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-invalid-descriptor/pom.xml
@@ -38,6 +38,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-log-file/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-log-file/pom.xml
@@ -47,6 +47,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-log4j/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-log4j/pom.xml
@@ -47,11 +47,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-model-interpolation/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-model-interpolation/pom.xml
@@ -39,11 +39,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.1.0</version>
+      <scope>provided</scope>
     </dependency>
     <!-- Test the resolution of the version -->
     <dependency>
@@ -54,6 +56,10 @@ under the License.
         <exclusion>
           <groupId>org.apache.maven.shared</groupId>
           <artifactId>maven-verifier</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-artifact</artifactId>
         </exclusion>
         <exclusion>
           <groupId>junit</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-no-default-comp/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-no-default-comp/pom.xml
@@ -47,6 +47,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-no-project/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-no-project/pom.xml
@@ -43,6 +43,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-online/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-online/pom.xml
@@ -46,6 +46,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-optional-mojos/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-optional-mojos/pom.xml
@@ -46,6 +46,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>3.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-packaging/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-packaging/pom.xml
@@ -46,6 +46,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <!--

--- a/core-it-support/core-it-plugins/maven-it-plugin-parameter-implementation/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-parameter-implementation/pom.xml
@@ -43,6 +43,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-plexus-component-api/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-plexus-component-api/pom.xml
@@ -44,6 +44,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-plexus-lifecycle/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-plexus-lifecycle/pom.xml
@@ -39,6 +39,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <!-- plexus -->
     <dependency>

--- a/core-it-support/core-it-plugins/maven-it-plugin-plexus-utils-11/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-plexus-utils-11/pom.xml
@@ -43,6 +43,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-plexus-utils-new/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-plexus-utils-new/pom.xml
@@ -43,6 +43,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-plugin-dependency/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-plugin-dependency/pom.xml
@@ -43,6 +43,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-project-interpolation/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-project-interpolation/pom.xml
@@ -39,11 +39,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <!-- Test the resolution of the version -->
     <dependency>
@@ -54,6 +56,10 @@ under the License.
         <exclusion>
           <groupId>org.apache.maven.shared</groupId>
           <artifactId>maven-verifier</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-artifact</artifactId>
         </exclusion>
         <exclusion>
           <groupId>junit</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-project/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-project/pom.xml
@@ -46,21 +46,25 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-setter/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-setter/pom.xml
@@ -45,6 +45,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-settings/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-settings/pom.xml
@@ -42,11 +42,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-settings</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
 
   </dependencies>

--- a/core-it-support/core-it-plugins/maven-it-plugin-settings/src/main/java/org/apache/maven/plugin/coreit/SettingsReadItMojo.java
+++ b/core-it-support/core-it-plugins/maven-it-plugin-settings/src/main/java/org/apache/maven/plugin/coreit/SettingsReadItMojo.java
@@ -23,7 +23,6 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.settings.io.xpp3.SettingsXpp3Writer;
-import org.codehaus.plexus.util.IOUtil;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -59,10 +58,8 @@ public class SettingsReadItMojo
             dumpFile.delete();
         }
         dumpFile.getParentFile().mkdirs();
-        FileWriter fw = null;
-        try
+        try ( FileWriter fw = new FileWriter( dumpFile ) )
         {
-            fw = new FileWriter( dumpFile );
             SettingsXpp3Writer writer = new SettingsXpp3Writer();
             writer.write( fw, settings );
         }
@@ -70,11 +67,5 @@ public class SettingsReadItMojo
         {
             throw new MojoExecutionException( e.getMessage(), e );
         }
-        finally
-        {
-            IOUtil.close( fw );
-        }
     }
-
-
 }

--- a/core-it-support/core-it-plugins/maven-it-plugin-singleton-component/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-singleton-component/pom.xml
@@ -46,6 +46,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-site/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-site/pom.xml
@@ -46,6 +46,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>
@@ -67,6 +68,12 @@ under the License.
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-exec</artifactId>
       <version>1.6.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-toolchain/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-toolchain/pom.xml
@@ -38,11 +38,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-toolchain</artifactId>
       <version>2.0.10</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-touch/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-touch/pom.xml
@@ -40,16 +40,19 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/core-it-support/core-it-plugins/maven-it-plugin-uses-properties/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-uses-properties/pom.xml
@@ -43,6 +43,7 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core-it-support/core-it-plugins/maven-it-plugin-uses-wagon/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-uses-wagon/pom.xml
@@ -39,11 +39,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact-manager</artifactId>
       <version>2.0.9</version>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>

--- a/core-it-support/core-it-plugins/mng6759-plugin-resolves-project-dependencies/pom.xml
+++ b/core-it-support/core-it-plugins/mng6759-plugin-resolves-project-dependencies/pom.xml
@@ -56,9 +56,10 @@ under the License.
       <scope>provided</scope>
     </dependency>
     <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-core</artifactId>
-        <version>${maven-version}</version>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${maven-version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/core-it-support/maven-it-plugin-bootstrap/pom.xml
+++ b/core-it-support/maven-it-plugin-bootstrap/pom.xml
@@ -42,11 +42,13 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>

--- a/core-it-support/maven-it-plugin-bootstrap/src/main/java/org/apache/maven/its/bootstrap/DownloadMojo.java
+++ b/core-it-support/maven-it-plugin-bootstrap/src/main/java/org/apache/maven/its/bootstrap/DownloadMojo.java
@@ -37,7 +37,6 @@ import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.ProjectBuildingRequest;
-import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.ArtifactTypeRegistry;
@@ -132,7 +131,7 @@ public class DownloadMojo
             throws MojoFailureException
     {
         Dependency coordinate = new Dependency();
-        String[] tokens = StringUtils.split( artifact, ":" );
+        String[] tokens = artifact.split( ":" );
         if ( tokens.length < 3 || tokens.length > 5 )
         {
             throw new MojoFailureException( "Invalid artifact, you must specify "


### PR DESCRIPTION
Fixes these kinds of warnings:
```
[INFO] --- maven-plugin-plugin:3.6.4:descriptor (default-descriptor) @ maven-it-plugin-bootstrap ---
[ERROR] Some dependencies of Maven Plugins are expected to be in provided scope.
Please make sure that dependencies listed below declared in POM
have set '<scope>provided</scope>' as well.The following dependencies are in wrong scope:
 * org.apache.maven:maven-plugin-api:jar:3.8.6:compile
 * org.apache.maven:maven-model:jar:3.8.6:compile
 * org.apache.maven:maven-artifact:jar:3.8.6:compile
 * org.apache.maven:maven-core:jar:3.8.6:compile
 * org.apache.maven:maven-settings:jar:3.8.6:compile
 * org.apache.maven:maven-settings-builder:jar:3.8.6:compile
 * org.apache.maven:maven-builder-support:jar:3.8.6:compile
 * org.apache.maven:maven-repository-metadata:jar:3.8.6:compile
 * org.apache.maven:maven-model-builder:jar:3.8.6:compile
 * org.apache.maven:maven-resolver-provider:jar:3.8.6:compile
```