### PR TITLE
[MNG-7661] Fix verifier 'clean' call in one of the ITs

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7112ProjectsWithNonRecursiveTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7112ProjectsWithNonRecursiveTest.java
@@ -43,8 +43,9 @@ public class MavenITmng7112ProjectsWithNonRecursiveTest
             throws IOException, VerificationException
     {
         final File projectDir = ResourceExtractor.simpleExtractResources( getClass(), PROJECT_PATH );
-        newVerifier( projectDir.getAbsolutePath() ).addCliArgument( "clean" );
-        newVerifier( projectDir.getAbsolutePath() ).execute();
+        Verifier cleaner = newVerifier( projectDir.getAbsolutePath() );
+        cleaner.addCliArgument( "clean" );
+        cleaner.execute();
 
         final Verifier verifier = newVerifier( projectDir.getAbsolutePath() );
 
@@ -67,8 +68,9 @@ public class MavenITmng7112ProjectsWithNonRecursiveTest
             throws IOException, VerificationException
     {
         final File projectDir = ResourceExtractor.simpleExtractResources( getClass(), PROJECT_PATH );
-        newVerifier( projectDir.getAbsolutePath() ).addCliArgument( "clean" );
-        newVerifier( projectDir.getAbsolutePath() ).execute();
+        Verifier cleaner = newVerifier( projectDir.getAbsolutePath() );
+        cleaner.addCliArgument( "clean" );
+        cleaner.execute();
 
         final Verifier verifier = newVerifier( projectDir.getAbsolutePath() );
 


### PR DESCRIPTION
@hboutemy here is the fix for the broken IT.

The reason it did not fail during a PR build in this repo (https://github.com/apache/maven-integration-testing/pull/225) is that we are not running PR builds with Maven 4, just latest 3.x (as far as I know). 

Maybe something that could be improved? Adding a build with latest Maven SNAPSHOT from master?

