### PR TITLE
[MNG-7665] Update Jetty to latest Java8 capable version

### DIFF
--- a/core-it-suite/pom.xml
+++ b/core-it-suite/pom.xml
@@ -81,7 +81,7 @@ under the License.
     <proxy.pass></proxy.pass>
     <proxy.nonProxyHosts>localhost</proxy.nonProxyHosts>
     <slf4jVersion>1.6.1</slf4jVersion>
-    <jetty9Version>9.0.4.v20130625</jetty9Version>
+    <jetty9Version>9.4.50.v20221201</jetty9Version>
 
     <stubPluginVersion>0.1-stub-SNAPSHOT</stubPluginVersion>
   </properties>

--- a/core-it-suite/pom.xml
+++ b/core-it-suite/pom.xml
@@ -105,25 +105,28 @@ under the License.
         scope <scope>test</scope> -->
     </dependency>
     <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-shared-utils</artifactId>
+      <version>0.9</version>
+    </dependency>
+
+    <!-- Jetty (as test HTTP server) -->
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
       <version>${jetty9Version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-shared-utils</artifactId>
-      <version>0.9</version>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-security</artifactId>
+      <version>${jetty9Version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
       <version>${jetty9Version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-      <version>${jetty9Version}</version>
-    </dependency>
+
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/core-it-suite/src/test/java/org/apache/maven/it/HttpServer.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/HttpServer.java
@@ -4,6 +4,7 @@ import com.google.common.io.ByteStreams;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.security.authentication.BasicAuthenticator;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.NetworkConnector;
@@ -110,7 +111,9 @@ public class HttpServer
         if ( username != null && password != null )
         {
             HashLoginService loginService = new HashLoginService( "Test Server" );
-            loginService.putUser( username, new Password( password ), new String[]{ "user" } );
+            UserStore userStore = new UserStore();
+            userStore.addUser( username, new Password( password ), new String[] { "user" } );
+            loginService.setUserStore( userStore );
             server.addBean( loginService );
 
             ConstraintSecurityHandler security = new ConstraintSecurityHandler();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0553SettingsAuthzEncryptionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0553SettingsAuthzEncryptionTest.java
@@ -29,6 +29,7 @@ import java.util.Properties;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
@@ -79,7 +80,9 @@ public class MavenITmng0553SettingsAuthzEncryptionTest
         constraintMapping.setPathSpec( "/*" );
 
         HashLoginService userRealm = new HashLoginService( "TestRealm" );
-        userRealm.putUser( "testuser", new Password( "testtest" ), new String[] { "user" } );
+        UserStore userStore = new UserStore();
+        userStore.addUser( "testuser", new Password( "testtest" ), new String[] { "user" } );
+        userRealm.setUserStore( userStore );
 
         server = new Server( 0 );
         ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0553SettingsAuthzEncryptionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0553SettingsAuthzEncryptionTest.java
@@ -35,15 +35,12 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
-import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Password;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.eclipse.jetty.servlet.ServletContextHandler.SECURITY;
-import static org.eclipse.jetty.servlet.ServletContextHandler.SESSIONS;
 import static org.eclipse.jetty.util.security.Constraint.__BASIC_AUTH;
 
 /**
@@ -85,8 +82,7 @@ public class MavenITmng0553SettingsAuthzEncryptionTest
         userRealm.setUserStore( userStore );
 
         server = new Server( 0 );
-        ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );
-        ConstraintSecurityHandler securityHandler = (ConstraintSecurityHandler) ctx.getSecurityHandler();
+        ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
         securityHandler.setLoginService( userRealm );
         securityHandler.setAuthMethod( __BASIC_AUTH );
         securityHandler.setConstraintMappings( new ConstraintMapping[] { constraintMapping } );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1895ScopeConflictResolutionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1895ScopeConflictResolutionTest.java
@@ -58,8 +58,8 @@ public class MavenITmng1895ScopeConflictResolutionTest
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng1895" );
         verifier.deleteDirectory( "target" );
-        verifier.addCliOption( "-s" );
-        verifier.addCliOption( "settings.xml" );
+        verifier.addCliArgument( "-s" );
+        verifier.addCliArgument( "settings.xml" );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
         verifier.addCliArgument( "validate" );
         verifier.execute();
@@ -239,8 +239,8 @@ public class MavenITmng1895ScopeConflictResolutionTest
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng1895" );
         verifier.deleteDirectory( "target" );
-        verifier.addCliOption( "-s" );
-        verifier.addCliOption( "settings.xml" );
+        verifier.addCliArgument( "-s" );
+        verifier.addCliArgument( "settings.xml" );
         Properties props = verifier.newDefaultFilterProperties();
         props.setProperty( "@scope.a@", scopeA );
         props.setProperty( "@scope.b@", scopeB );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1895ScopeConflictResolutionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1895ScopeConflictResolutionTest.java
@@ -24,7 +24,7 @@ import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -60,7 +60,7 @@ public class MavenITmng1895ScopeConflictResolutionTest
         verifier.deleteDirectory( "target" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterMap() );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();
@@ -241,9 +241,9 @@ public class MavenITmng1895ScopeConflictResolutionTest
         verifier.deleteDirectory( "target" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        Properties props = verifier.newDefaultFilterProperties();
-        props.setProperty( "@scope.a@", scopeA );
-        props.setProperty( "@scope.b@", scopeB );
+        Map<String, String> props = verifier.newDefaultFilterMap();
+        props.put( "@scope.a@", scopeA );
+        props.put( "@scope.b@", scopeB );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", props );
         verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8", props );
         verifier.setLogFileName( "log-" + scopeB + "-vs-" + scopeA + ".txt" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1895ScopeConflictResolutionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1895ScopeConflictResolutionTest.java
@@ -24,7 +24,7 @@ import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
 import java.util.List;
-import java.util.Map;
+import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
@@ -58,9 +58,9 @@ public class MavenITmng1895ScopeConflictResolutionTest
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng1895" );
         verifier.deleteDirectory( "target" );
-        verifier.addCliArgument( "-s" );
-        verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterMap() );
+        verifier.addCliOption( "-s" );
+        verifier.addCliOption( "settings.xml" );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();
@@ -239,11 +239,11 @@ public class MavenITmng1895ScopeConflictResolutionTest
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng1895" );
         verifier.deleteDirectory( "target" );
-        verifier.addCliArgument( "-s" );
-        verifier.addCliArgument( "settings.xml" );
-        Map<String, String> props = verifier.newDefaultFilterMap();
-        props.put( "@scope.a@", scopeA );
-        props.put( "@scope.b@", scopeB );
+        verifier.addCliOption( "-s" );
+        verifier.addCliOption( "settings.xml" );
+        Properties props = verifier.newDefaultFilterProperties();
+        props.setProperty( "@scope.a@", scopeA );
+        props.setProperty( "@scope.b@", scopeB );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", props );
         verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8", props );
         verifier.setLogFileName( "log-" + scopeB + "-vs-" + scopeA + ".txt" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3953AuthenticatedDeploymentTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3953AuthenticatedDeploymentTest.java
@@ -30,6 +30,7 @@ import java.io.File;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Request;
@@ -103,7 +104,9 @@ public class MavenITmng3953AuthenticatedDeploymentTest
         constraintMapping.setPathSpec( "/*" );
 
         HashLoginService userRealm = new HashLoginService( "TestRealm" );
-        userRealm.putUser( "testuser", new Password( "testtest" ), new String[] { "deployer" } );
+        UserStore userStore = new UserStore();
+        userStore.addUser( "testuser", new Password( "testtest" ), new String[] { "deployer" } );
+        userRealm.setUserStore( userStore );
 
         server = new Server( 0 );
         ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3953AuthenticatedDeploymentTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3953AuthenticatedDeploymentTest.java
@@ -37,15 +37,12 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
-import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Password;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.eclipse.jetty.servlet.ServletContextHandler.SECURITY;
-import static org.eclipse.jetty.servlet.ServletContextHandler.SESSIONS;
 import static org.eclipse.jetty.util.security.Constraint.__BASIC_AUTH;
 
 /**
@@ -109,8 +106,7 @@ public class MavenITmng3953AuthenticatedDeploymentTest
         userRealm.setUserStore( userStore );
 
         server = new Server( 0 );
-        ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );
-        ConstraintSecurityHandler securityHandler = (ConstraintSecurityHandler) ctx.getSecurityHandler();
+        ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
         securityHandler.setLoginService( userRealm );
         securityHandler.setAuthMethod( __BASIC_AUTH );
         securityHandler.setConstraintMappings( new ConstraintMapping[] { constraintMapping } );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4068AuthenticatedMirrorTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4068AuthenticatedMirrorTest.java
@@ -34,15 +34,12 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
-import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Password;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.eclipse.jetty.servlet.ServletContextHandler.SECURITY;
-import static org.eclipse.jetty.servlet.ServletContextHandler.SESSIONS;
 import static org.eclipse.jetty.util.security.Constraint.__BASIC_AUTH;
 
 /**
@@ -87,8 +84,7 @@ public class MavenITmng4068AuthenticatedMirrorTest
         userRealm.setUserStore( userStore );
 
         server = new Server( 0 );
-        ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );
-        ConstraintSecurityHandler securityHandler = (ConstraintSecurityHandler) ctx.getSecurityHandler();
+        ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
         securityHandler.setLoginService( userRealm );
         securityHandler.setAuthMethod( __BASIC_AUTH );
         securityHandler.setConstraintMappings( new ConstraintMapping[] { constraintMapping } );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4068AuthenticatedMirrorTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4068AuthenticatedMirrorTest.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
@@ -81,7 +82,9 @@ public class MavenITmng4068AuthenticatedMirrorTest
         constraintMapping.setPathSpec( "/*" );
 
         HashLoginService userRealm = new HashLoginService( "TestRealm" );
-        userRealm.putUser( "testuser", new Password( "testtest" ), new String[] { "user" } );
+        UserStore userStore = new UserStore();
+        userStore.addUser( "testuser", new Password( "testtest" ), new String[] { "user" } );
+        userRealm.setUserStore( userStore );
 
         server = new Server( 0 );
         ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4235HttpAuthDeploymentChecksumsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4235HttpAuthDeploymentChecksumsTest.java
@@ -45,7 +45,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
-import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Password;
@@ -54,8 +53,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-import static org.eclipse.jetty.servlet.ServletContextHandler.SECURITY;
-import static org.eclipse.jetty.servlet.ServletContextHandler.SESSIONS;
 import static org.eclipse.jetty.util.security.Constraint.__BASIC_AUTH;
 
 /**
@@ -102,8 +99,7 @@ public class MavenITmng4235HttpAuthDeploymentChecksumsTest
         userStore.addUser( "testuser", new Password( "testpass" ), new String[] { "deployer" } );
         userRealm.setUserStore( userStore );
 
-        ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );
-        ConstraintSecurityHandler securityHandler = (ConstraintSecurityHandler) ctx.getSecurityHandler();
+        ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
         securityHandler.setLoginService( userRealm );
         securityHandler.setAuthMethod( __BASIC_AUTH );
         securityHandler.setConstraintMappings( new ConstraintMapping[] { constraintMapping } );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4235HttpAuthDeploymentChecksumsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4235HttpAuthDeploymentChecksumsTest.java
@@ -204,7 +204,7 @@ public class MavenITmng4235HttpAuthDeploymentChecksumsTest
 
             if ( "PUT".equals( request.getMethod() ) )
             {
-                Resource resource = getResource( request );
+                Resource resource = getResource( request.getPathInfo() );
 
                 // NOTE: This can get called concurrently but File.mkdirs() isn't thread-safe in all JREs
                 File dir = resource.getFile().getParentFile();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4235HttpAuthDeploymentChecksumsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4235HttpAuthDeploymentChecksumsTest.java
@@ -38,6 +38,7 @@ import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
@@ -97,7 +98,9 @@ public class MavenITmng4235HttpAuthDeploymentChecksumsTest
         constraintMapping.setPathSpec( "/*" );
 
         HashLoginService userRealm = new HashLoginService( "TestRealm" );
-        userRealm.putUser( "testuser", new Password( "testpass" ), new String[] { "deployer" } );
+        UserStore userStore = new UserStore();
+        userStore.addUser( "testuser", new Password( "testpass" ), new String[] { "deployer" } );
+        userRealm.setUserStore( userStore );
 
         ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );
         ConstraintSecurityHandler securityHandler = (ConstraintSecurityHandler) ctx.getSecurityHandler();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4413MirroringOfDependencyRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4413MirroringOfDependencyRepoTest.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
@@ -78,7 +79,9 @@ public class MavenITmng4413MirroringOfDependencyRepoTest
         constraintMapping.setPathSpec( "/*" );
 
         HashLoginService userRealm = new HashLoginService( "TestRealm" );
-        userRealm.putUser( "testuser", new Password( "testtest" ), new String[] { "user" } );
+        UserStore userStore = new UserStore();
+        userStore.addUser( "testuser", new Password( "testtest" ), new String[] { "user" } );
+        userRealm.setUserStore( userStore );
 
         Server server = new Server( 0 );
         ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4413MirroringOfDependencyRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4413MirroringOfDependencyRepoTest.java
@@ -34,13 +34,10 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
-import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Password;
 import org.junit.jupiter.api.Test;
 
-import static org.eclipse.jetty.servlet.ServletContextHandler.SECURITY;
-import static org.eclipse.jetty.servlet.ServletContextHandler.SESSIONS;
 import static org.eclipse.jetty.util.security.Constraint.__BASIC_AUTH;
 
 /**
@@ -84,8 +81,7 @@ public class MavenITmng4413MirroringOfDependencyRepoTest
         userRealm.setUserStore( userStore );
 
         Server server = new Server( 0 );
-        ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );
-        ConstraintSecurityHandler securityHandler = (ConstraintSecurityHandler) ctx.getSecurityHandler();
+        ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
         securityHandler.setLoginService( userRealm );
         securityHandler.setAuthMethod( __BASIC_AUTH );
         securityHandler.setConstraintMappings( new ConstraintMapping[] { constraintMapping } );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4469AuthenticatedDeploymentToCustomRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4469AuthenticatedDeploymentToCustomRepoTest.java
@@ -37,15 +37,12 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
-import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Password;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.eclipse.jetty.servlet.ServletContextHandler.SECURITY;
-import static org.eclipse.jetty.servlet.ServletContextHandler.SESSIONS;
 import static org.eclipse.jetty.util.security.Constraint.__BASIC_AUTH;
 
 /**
@@ -109,8 +106,7 @@ public class MavenITmng4469AuthenticatedDeploymentToCustomRepoTest
         userRealm.setUserStore( userStore );
 
         server = new Server( 0 );
-        ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );
-        ConstraintSecurityHandler securityHandler = (ConstraintSecurityHandler) ctx.getSecurityHandler();
+        ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
         securityHandler.setLoginService( userRealm );
         securityHandler.setAuthMethod( __BASIC_AUTH );
         securityHandler.setConstraintMappings( new ConstraintMapping[] { constraintMapping } );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4469AuthenticatedDeploymentToCustomRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4469AuthenticatedDeploymentToCustomRepoTest.java
@@ -30,6 +30,7 @@ import java.io.File;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Request;
@@ -103,7 +104,9 @@ public class MavenITmng4469AuthenticatedDeploymentToCustomRepoTest
         constraintMapping.setPathSpec( "/*" );
 
         HashLoginService userRealm = new HashLoginService( "TestRealm" );
-        userRealm.putUser( "testuser", new Password( "testtest" ), new String[] { "deployer" } );
+        UserStore userStore = new UserStore();
+        userStore.addUser( "testuser", new Password( "testtest" ), new String[] { "deployer" } );
+        userRealm.setUserStore( userStore );
 
         server = new Server( 0 );
         ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4470AuthenticatedDeploymentToProxyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4470AuthenticatedDeploymentToProxyTest.java
@@ -43,15 +43,12 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
-import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Password;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.eclipse.jetty.servlet.ServletContextHandler.SECURITY;
-import static org.eclipse.jetty.servlet.ServletContextHandler.SESSIONS;
 import static org.eclipse.jetty.util.security.Constraint.__BASIC_AUTH;
 
 /**
@@ -160,8 +157,7 @@ public class MavenITmng4470AuthenticatedDeploymentToProxyTest
         userRealm.setUserStore( userStore );
 
         server = new Server( 0 );
-        ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );
-        ConstraintSecurityHandler securityHandler = (ConstraintSecurityHandler) ctx.getSecurityHandler();
+        ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
         securityHandler.setLoginService( userRealm );
         securityHandler.setAuthMethod( __BASIC_AUTH );
         securityHandler.setConstraintMappings( new ConstraintMapping[] { constraintMapping } );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4470AuthenticatedDeploymentToProxyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4470AuthenticatedDeploymentToProxyTest.java
@@ -36,6 +36,7 @@ import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Request;
@@ -43,7 +44,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.util.B64Code;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Password;
 import org.junit.jupiter.api.AfterEach;
@@ -92,7 +92,7 @@ public class MavenITmng4470AuthenticatedDeploymentToProxyTest
                 if ( auth != null )
                 {
                     auth = auth.substring( auth.indexOf( ' ' ) + 1 ).trim();
-                    auth = B64Code.decode( auth, StandardCharsets.US_ASCII.name() );
+                    auth = new String( java.util.Base64.getDecoder().decode( auth ), StandardCharsets.US_ASCII );
                 }
                 System.out.println( "Proxy-Authorization: " + auth );
 
@@ -155,7 +155,9 @@ public class MavenITmng4470AuthenticatedDeploymentToProxyTest
         constraintMapping.setPathSpec( "/*" );
 
         HashLoginService userRealm = new HashLoginService( "TestRealm" );
-        userRealm.putUser( "testuser", new Password( "testtest" ), new String[] { "deployer" } );
+        UserStore userStore = new UserStore();
+        userStore.addUser( "testuser", new Password( "testtest" ), new String[] { "deployer" } );
+        userRealm.setUserStore( userStore );
 
         server = new Server( 0 );
         ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );
@@ -224,8 +226,8 @@ public class MavenITmng4470AuthenticatedDeploymentToProxyTest
         verifier.setAutoclean( false );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8",
                              Collections.singletonMap( "@port@", Integer.toString( port ) ) );
-        verifier.addCliOption( "--settings" );
-        verifier.addCliOption( "settings.xml" );
+        verifier.addCliArgument( "--settings" );
+        verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4470AuthenticatedDeploymentToProxyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4470AuthenticatedDeploymentToProxyTest.java
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -89,7 +90,7 @@ public class MavenITmng4470AuthenticatedDeploymentToProxyTest
                 if ( auth != null )
                 {
                     auth = auth.substring( auth.indexOf( ' ' ) + 1 ).trim();
-                    auth = new String( java.util.Base64.getDecoder().decode( auth ), StandardCharsets.US_ASCII );
+                    auth = new String( Base64.getDecoder().decode( auth ), StandardCharsets.US_ASCII );
                 }
                 System.out.println( "Proxy-Authorization: " + auth );
 

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4489MirroringOfExtensionRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4489MirroringOfExtensionRepoTest.java
@@ -34,13 +34,10 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
-import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Password;
 import org.junit.jupiter.api.Test;
 
-import static org.eclipse.jetty.servlet.ServletContextHandler.SECURITY;
-import static org.eclipse.jetty.servlet.ServletContextHandler.SESSIONS;
 import static org.eclipse.jetty.util.security.Constraint.__BASIC_AUTH;
 
 /**
@@ -84,8 +81,7 @@ public class MavenITmng4489MirroringOfExtensionRepoTest
         userRealm.setUserStore( userStore );
 
         Server server = new Server( 0 );
-        ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );
-        ConstraintSecurityHandler securityHandler = (ConstraintSecurityHandler) ctx.getSecurityHandler();
+        ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
         securityHandler.setLoginService( userRealm );
         securityHandler.setAuthMethod( __BASIC_AUTH );
         securityHandler.setConstraintMappings( new ConstraintMapping[] { constraintMapping } );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4489MirroringOfExtensionRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4489MirroringOfExtensionRepoTest.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
@@ -78,7 +79,9 @@ public class MavenITmng4489MirroringOfExtensionRepoTest
         constraintMapping.setPathSpec( "/*" );
 
         HashLoginService userRealm = new HashLoginService( "TestRealm" );
-        userRealm.putUser( "testuser", new Password( "testtest" ), new String[] { "user" } );
+        UserStore userStore = new UserStore();
+        userStore.addUser( "testuser", new Password( "testtest" ), new String[] { "user" } );
+        userRealm.setUserStore( userStore );
 
         Server server = new Server( 0 );
         ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4561MirroringOfPluginRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4561MirroringOfPluginRepoTest.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
@@ -78,7 +79,9 @@ public class MavenITmng4561MirroringOfPluginRepoTest
         constraintMapping.setPathSpec( "/*" );
 
         HashLoginService userRealm = new HashLoginService( "TestRealm" );
-        userRealm.putUser( "testuser", new Password( "testtest" ), new String[] { "user" } );
+        UserStore userStore = new UserStore();
+        userStore.addUser( "testuser", new Password( "testtest" ), new String[] { "user" } );
+        userRealm.setUserStore( userStore );
 
         Server server = new Server( 0 );
         ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4561MirroringOfPluginRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4561MirroringOfPluginRepoTest.java
@@ -34,13 +34,10 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
-import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Password;
 import org.junit.jupiter.api.Test;
 
-import static org.eclipse.jetty.servlet.ServletContextHandler.SECURITY;
-import static org.eclipse.jetty.servlet.ServletContextHandler.SESSIONS;
 import static org.eclipse.jetty.util.security.Constraint.__BASIC_AUTH;
 
 /**
@@ -84,8 +81,7 @@ public class MavenITmng4561MirroringOfPluginRepoTest
         userRealm.setUserStore( userStore );
 
         Server server = new Server( 0 );
-        ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );
-        ConstraintSecurityHandler securityHandler = (ConstraintSecurityHandler) ctx.getSecurityHandler();
+        ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
         securityHandler.setLoginService( userRealm );
         securityHandler.setAuthMethod( __BASIC_AUTH );
         securityHandler.setConstraintMappings( new ConstraintMapping[] { constraintMapping } );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4729MirrorProxyAuthUsedByProjectBuilderTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4729MirrorProxyAuthUsedByProjectBuilderTest.java
@@ -34,13 +34,10 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
-import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Password;
 import org.junit.jupiter.api.Test;
 
-import static org.eclipse.jetty.servlet.ServletContextHandler.SECURITY;
-import static org.eclipse.jetty.servlet.ServletContextHandler.SESSIONS;
 import static org.eclipse.jetty.util.security.Constraint.__BASIC_AUTH;
 
 /**
@@ -84,8 +81,7 @@ public class MavenITmng4729MirrorProxyAuthUsedByProjectBuilderTest
         userRealm.setUserStore( userStore );
 
         Server server = new Server( 0 );
-        ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );
-        ConstraintSecurityHandler securityHandler = (ConstraintSecurityHandler) ctx.getSecurityHandler();
+        ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
         securityHandler.setLoginService( userRealm );
         securityHandler.setAuthMethod( __BASIC_AUTH );
         securityHandler.setConstraintMappings( new ConstraintMapping[] { constraintMapping } );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4729MirrorProxyAuthUsedByProjectBuilderTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4729MirrorProxyAuthUsedByProjectBuilderTest.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
@@ -78,7 +79,9 @@ public class MavenITmng4729MirrorProxyAuthUsedByProjectBuilderTest
         constraintMapping.setPathSpec( "/*" );
 
         HashLoginService userRealm = new HashLoginService( "TestRealm" );
-        userRealm.putUser( "testuser", new Password( "testtest" ), new String[] { "user" } );
+        UserStore userStore = new UserStore();
+        userStore.addUser( "testuser", new Password( "testtest" ), new String[] { "user" } );
+        userRealm.setUserStore( userStore );
 
         Server server = new Server( 0 );
         ServletContextHandler ctx = new ServletContextHandler( server, "/", SESSIONS | SECURITY );


### PR DESCRIPTION
Update Jetty to latest 9.4.50, last Java 8 capable version. Apply API changes and also remove jetty-servlet as ITs does NOT use servlet aspect of Jetty HTTP server.. This will simplify our lives in future, to make jump to later versions (that are Java 11+). Also, drop jetty-servlet as test do not use any servlet aspect.

---

https://issues.apache.org/jira/browse/MNG-7665

