### PR TITLE
[MNG-7661] Replace deprecated 'verifier.newDefaultFilterProperties()'

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0010DependencyClosureResolutionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0010DependencyClosureResolutionTest.java
@@ -52,7 +52,7 @@ public class MavenIT0010DependencyClosureResolutionTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.it0010" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0011DefaultVersionByDependencyManagementTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0011DefaultVersionByDependencyManagementTest.java
@@ -49,7 +49,7 @@ public class MavenIT0011DefaultVersionByDependencyManagementTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.it0011" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0018DependencyManagementTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0018DependencyManagementTest.java
@@ -49,7 +49,7 @@ public class MavenIT0018DependencyManagementTest
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.it0018" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "org.apache.maven.its.plugins:maven-it-plugin-dependency-resolution:2.1-SNAPSHOT:compile" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0021PomProfileTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0021PomProfileTest.java
@@ -50,7 +50,7 @@ public class MavenIT0021PomProfileTest
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.it0021" );
         verifier.getSystemProperties().setProperty( "includeProfile", "true" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "-Pprofile-2" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0085TransitiveSystemScopeTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0085TransitiveSystemScopeTest.java
@@ -54,7 +54,7 @@ public class MavenIT0085TransitiveSystemScopeTest
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.it0085" );
         verifier.getSystemProperties().setProperty( "test.home", testDir.getAbsolutePath() );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0087PluginRealmWithProjectLevelDepsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0087PluginRealmWithProjectLevelDepsTest.java
@@ -57,7 +57,7 @@ public class MavenIT0087PluginRealmWithProjectLevelDepsTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.it0087" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0142DirectDependencyScopesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0142DirectDependencyScopesTest.java
@@ -24,7 +24,6 @@ import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
 import java.util.List;
-import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
@@ -61,9 +60,8 @@ public class MavenIT0142DirectDependencyScopesTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.it0142" );
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8", filterProps );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
+        verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8" );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0143TransitiveDependencyScopesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0143TransitiveDependencyScopesTest.java
@@ -24,7 +24,7 @@ import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -250,8 +250,8 @@ public class MavenIT0143TransitiveDependencyScopesTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target-" + scope );
         verifier.deleteArtifacts( "org.apache.maven.its.it0143" );
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        filterProps.setProperty( "@scope@", scope );
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
+        filterProps.put( "@scope@", scope );
         verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8", filterProps );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
         verifier.addCliArgument( "--settings" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0146InstallerSnapshotNaming.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0146InstallerSnapshotNaming.java
@@ -25,7 +25,7 @@ import org.apache.maven.shared.verifier.Verifier;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
-import java.util.Properties;
+import java.util.Map;
 
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
@@ -91,9 +91,9 @@ public class MavenIT0146InstallerSnapshotNaming
     {
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
 
-        Properties properties = verifier.newDefaultFilterProperties();
-        properties.setProperty( "@host@", InetAddress.getLoopbackAddress().getCanonicalHostName() );
-        properties.setProperty( "@port@", Integer.toString( port ) );
+        Map<String, String> properties = verifier.newDefaultFilterMap();
+        properties.put( "@host@", InetAddress.getLoopbackAddress().getCanonicalHostName() );
+        properties.put( "@port@", Integer.toString( port ) );
 
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", properties );
 
@@ -131,9 +131,9 @@ public class MavenIT0146InstallerSnapshotNaming
 
         verifier = newVerifier( testDir.getAbsolutePath() );
 
-        Properties properties = verifier.newDefaultFilterProperties();
-        properties.setProperty( "@host@", InetAddress.getLoopbackAddress().getCanonicalHostName() );
-        properties.setProperty( "@port@", Integer.toString( port ) );
+        Map<String, String> properties = verifier.newDefaultFilterMap();
+        properties.put( "@host@", InetAddress.getLoopbackAddress().getCanonicalHostName() );
+        properties.put( "@port@", Integer.toString( port ) );
 
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", properties );
 

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0377PluginLookupFromPrefixTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0377PluginLookupFromPrefixTest.java
@@ -56,7 +56,7 @@ public class MavenITmng0377PluginLookupFromPrefixTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng0377" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "-Dtouch.outputFile=target/file.txt" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0449PluginVersionResolutionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0449PluginVersionResolutionTest.java
@@ -67,7 +67,7 @@ public class MavenITmng0449PluginVersionResolutionTest
         }
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();
@@ -112,7 +112,7 @@ public class MavenITmng0449PluginVersionResolutionTest
         }
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "org.apache.maven.its.mng0449:maven-it-plugin-a:touch" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0461TolerateMissingDependencyPomTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0461TolerateMissingDependencyPomTest.java
@@ -56,7 +56,7 @@ public class MavenITmng0461TolerateMissingDependencyPomTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng0461" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0479OverrideCentralRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0479OverrideCentralRepoTest.java
@@ -69,7 +69,7 @@ public class MavenITmng0479OverrideCentralRepoTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
 
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "org.apache.maven.its.plugins:maven-it-plugin-expression:2.1-SNAPSHOT:eval" );
@@ -134,7 +134,7 @@ public class MavenITmng0479OverrideCentralRepoTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng0479" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );
@@ -152,7 +152,7 @@ public class MavenITmng0479OverrideCentralRepoTest
         verifier = newVerifier( new File( testDir, "test-2" ).getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         try
@@ -172,7 +172,7 @@ public class MavenITmng0479OverrideCentralRepoTest
         verifier = newVerifier( new File( testDir, "test-3" ).getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         try
@@ -193,7 +193,7 @@ public class MavenITmng0479OverrideCentralRepoTest
         verifier = newVerifier( new File( testDir, "test-4" ).getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         try

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0505VersionRangeTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0505VersionRangeTest.java
@@ -60,7 +60,7 @@ public class MavenITmng0505VersionRangeTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng0505" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0553SettingsAuthzEncryptionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0553SettingsAuthzEncryptionTest.java
@@ -23,8 +23,9 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
@@ -127,8 +128,8 @@ public class MavenITmng0553SettingsAuthzEncryptionTest
     {
         testDir = new File( testDir, "test-1" );
 
-        Properties filterProps = new Properties();
-        filterProps.setProperty( "@port@", Integer.toString( port ) );
+        Map<String, String> filterProps = new HashMap<>();
+        filterProps.put( "@port@", Integer.toString( port ) );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
@@ -157,11 +158,11 @@ public class MavenITmng0553SettingsAuthzEncryptionTest
     {
         testDir = new File( testDir, "test-2" );
 
-        Properties filterProps = new Properties();
-        filterProps.setProperty( "@port@", Integer.toString( port ) );
+        Map<String, String> filterProps = new HashMap<>();
+        filterProps.put( "@port@", Integer.toString( port ) );
         // NOTE: The upper-case scheme name is essential part of the test
         String secUrl = "FILE://" + new File( testDir, "relocated-settings-security.xml" ).toURI().getRawPath();
-        filterProps.setProperty( "@relocation@", secUrl );
+        filterProps.put( "@relocation@", secUrl );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0666IgnoreLegacyPomTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0666IgnoreLegacyPomTest.java
@@ -57,7 +57,7 @@ public class MavenITmng0666IgnoreLegacyPomTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.it0059" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0818WarDepsNotTransitiveTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0818WarDepsNotTransitiveTest.java
@@ -57,7 +57,7 @@ public class MavenITmng0818WarDepsNotTransitiveTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.it0080" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0820ConflictResolutionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0820ConflictResolutionTest.java
@@ -56,7 +56,7 @@ public class MavenITmng0820ConflictResolutionTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng0820" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0836PluginParentResolutionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0836PluginParentResolutionTest.java
@@ -58,7 +58,7 @@ public class MavenITmng0836PluginParentResolutionTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng836" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         // Maven 3.x aims to separate plugins and project dependencies (MNG-4191)

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0870ReactorAwarePluginDiscoveryTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0870ReactorAwarePluginDiscoveryTest.java
@@ -57,7 +57,7 @@ public class MavenITmng0870ReactorAwarePluginDiscoveryTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "project/target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng0870" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "initialize" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0947OptionalDependencyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0947OptionalDependencyTest.java
@@ -59,7 +59,7 @@ public class MavenITmng0947OptionalDependencyTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng0947" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0956ComponentInjectionViaProjectLevelPluginDepTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0956ComponentInjectionViaProjectLevelPluginDepTest.java
@@ -55,7 +55,7 @@ public class MavenITmng0956ComponentInjectionViaProjectLevelPluginDepTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng0956" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1088ReactorPluginResolutionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1088ReactorPluginResolutionTest.java
@@ -58,7 +58,7 @@ public class MavenITmng1088ReactorPluginResolutionTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "client/target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng1088" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         // NOTE: It's essential part of the test to invoke a phase before "compile"

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1142VersionRangeIntersectionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1142VersionRangeIntersectionTest.java
@@ -78,7 +78,7 @@ public class MavenITmng1142VersionRangeIntersectionTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng1142" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1233WarDepWithProvidedScopeTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1233WarDepWithProvidedScopeTest.java
@@ -56,7 +56,7 @@ public class MavenITmng1233WarDepWithProvidedScopeTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.it0083" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1323AntrunDependenciesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1323AntrunDependenciesTest.java
@@ -61,7 +61,7 @@ public class MavenITmng1323AntrunDependenciesTest
         verifier.deleteDirectory( "b/target" );
         verifier.deleteDirectory( "c/target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng1323" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1349ChecksumFormatsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1349ChecksumFormatsTest.java
@@ -55,7 +55,7 @@ public class MavenITmng1349ChecksumFormatsTest
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng1349" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1412DependenciesOrderTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1412DependenciesOrderTest.java
@@ -53,7 +53,7 @@ public class MavenITmng1412DependenciesOrderTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng1412" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1703PluginMgmtDepInheritanceTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1703PluginMgmtDepInheritanceTest.java
@@ -56,7 +56,7 @@ public class MavenITmng1703PluginMgmtDepInheritanceTest
 
         Verifier verifier = newVerifier( new File( testDir, "child" ).getAbsolutePath() );
         verifier.setAutoclean( false );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.deleteDirectory( "target" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1751ForcedMetadataUpdateDuringDeploymentTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1751ForcedMetadataUpdateDuringDeploymentTest.java
@@ -73,7 +73,7 @@ public class MavenITmng1751ForcedMetadataUpdateDuringDeploymentTest
         verifier = newVerifier( new File( testDir, "test" ).getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng1751" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1895ScopeConflictResolutionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1895ScopeConflictResolutionTest.java
@@ -24,7 +24,7 @@ import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -60,7 +60,7 @@ public class MavenITmng1895ScopeConflictResolutionTest
         verifier.deleteDirectory( "target" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();
@@ -241,9 +241,9 @@ public class MavenITmng1895ScopeConflictResolutionTest
         verifier.deleteDirectory( "target" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        Properties props = verifier.newDefaultFilterProperties();
-        props.setProperty( "@scope.a@", scopeA );
-        props.setProperty( "@scope.b@", scopeB );
+        Map<String, String> props = verifier.newDefaultFilterMap();
+        props.put( "@scope.a@", scopeA );
+        props.put( "@scope.b@", scopeB );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", props );
         verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8", props );
         verifier.setLogFileName( "log-" + scopeB + "-vs-" + scopeA + ".txt" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2098VersionRangeSatisfiedFromWrongRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2098VersionRangeSatisfiedFromWrongRepoTest.java
@@ -59,7 +59,7 @@ public class MavenITmng2098VersionRangeSatisfiedFromWrongRepoTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng2098" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2123VersionRangeDependencyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2123VersionRangeDependencyTest.java
@@ -49,7 +49,7 @@ public class MavenITmng2123VersionRangeDependencyTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng2123" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2174PluginDepsManagedByParentProfileTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2174PluginDepsManagedByParentProfileTest.java
@@ -58,7 +58,7 @@ public class MavenITmng2174PluginDepsManagedByParentProfileTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng2174" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2228ComponentInjectionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2228ComponentInjectionTest.java
@@ -57,7 +57,7 @@ public class MavenITmng2228ComponentInjectionTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng2228" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2305MultipleProxiesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2305MultipleProxiesTest.java
@@ -29,7 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -105,9 +105,9 @@ public class MavenITmng2305MultipleProxiesTest
             verifier.setAutoclean( false );
             verifier.deleteDirectory( "target" );
             verifier.deleteArtifacts( "org.apache.maven.its.mng2305" );
-            Properties filterProps = verifier.newDefaultFilterProperties();
-            filterProps.setProperty( "@proxy.http@", Integer.toString( httpPort ) );
-            filterProps.setProperty( "@proxy.https@", Integer.toString( proxyPort ) );
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
+            filterProps.put( "@proxy.http@", Integer.toString( httpPort ) );
+            filterProps.put( "@proxy.https@", Integer.toString( proxyPort ) );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "--settings" );
             verifier.addCliArgument( "settings.xml" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2387InactiveProxyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2387InactiveProxyTest.java
@@ -24,7 +24,7 @@ import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
 import java.net.InetAddress;
-import java.util.Properties;
+import java.util.Map;
 
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
@@ -126,10 +126,10 @@ public class MavenITmng2387InactiveProxyTest
     {
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
 
-        Properties properties = verifier.newDefaultFilterProperties();
-        properties.setProperty( "@host@", InetAddress.getLoopbackAddress().getCanonicalHostName() );
-        properties.setProperty( "@port@", Integer.toString( port ) );
-        properties.setProperty( "@proxyPort@", Integer.toString( proxyPort ) );
+        Map<String, String> properties = verifier.newDefaultFilterMap();
+        properties.put( "@host@", InetAddress.getLoopbackAddress().getCanonicalHostName() );
+        properties.put( "@port@", Integer.toString( port ) );
+        properties.put( "@proxyPort@", Integer.toString( proxyPort ) );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", properties );
 
         verifier.setAutoclean( false );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2432PluginPrefixOrderTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2432PluginPrefixOrderTest.java
@@ -58,7 +58,7 @@ public class MavenITmng2432PluginPrefixOrderTest
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng2432.pom" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng2432.settings" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "it:touch" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2486TimestampedDependencyVersionInterpolationTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2486TimestampedDependencyVersionInterpolationTest.java
@@ -83,7 +83,7 @@ public class MavenITmng2486TimestampedDependencyVersionInterpolationTest
         verifier.deleteDirectory( "target" );
         // enforce remote resolution
         verifier.deleteArtifacts( "org.apache.maven.its.mng2486" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2695OfflinePluginSnapshotsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2695OfflinePluginSnapshotsTest.java
@@ -61,7 +61,7 @@ public class MavenITmng2695OfflinePluginSnapshotsTest
             verifier.deleteArtifacts( "org.apache.maven.its.mng2695" );
             verifier.setAutoclean( false );
             verifier.setLogFileName( "log1.txt" );
-            verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+            verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
             verifier.addCliArgument( "--settings" );
             verifier.addCliArgument( "settings.xml" );
             verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2744checksumVerificationTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2744checksumVerificationTest.java
@@ -55,7 +55,7 @@ public class MavenITmng2744checksumVerificationTest
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng2744" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2749ExtensionAvailableToPluginTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2749ExtensionAvailableToPluginTest.java
@@ -56,7 +56,7 @@ public class MavenITmng2749ExtensionAvailableToPluginTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng2749" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2861RelocationsAndRangesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2861RelocationsAndRangesTest.java
@@ -51,7 +51,7 @@ public class MavenITmng2861RelocationsAndRangesTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "A/target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng2861" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2865MirrorWildcardTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2865MirrorWildcardTest.java
@@ -23,7 +23,6 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
-import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
@@ -98,8 +97,7 @@ public class MavenITmng2865MirrorWildcardTest
         Verifier verifier = newVerifier( new File( testDir, project ).getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng2865" );
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2892HideCorePlexusUtilsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2892HideCorePlexusUtilsTest.java
@@ -58,7 +58,7 @@ public class MavenITmng2892HideCorePlexusUtilsTest
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifact( "org.codehaus.plexus", "plexus-utils", "0.1-mng2892", "jar" );
         verifier.deleteArtifact( "org.codehaus.plexus", "plexus-utils", "0.1-mng2892", "pom" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2926PluginPrefixOrderTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2926PluginPrefixOrderTest.java
@@ -69,8 +69,7 @@ public class MavenITmng2926PluginPrefixOrderTest
         verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.setLogFileName( "log-default.txt" );
-        verifier.filterFile( "settings-default-template.xml", "settings-default.xml", "UTF-8",
-            verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-default-template.xml", "settings-default.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings-default.xml" );
         verifier.addCliArgument( "mng-2926:apache" );
@@ -80,8 +79,7 @@ public class MavenITmng2926PluginPrefixOrderTest
         verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.setLogFileName( "log-custom.txt" );
-        verifier.filterFile( "settings-custom-template.xml", "settings-custom.xml", "UTF-8",
-            verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-custom-template.xml", "settings-custom.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings-custom.xml" );
         verifier.addCliArgument( "mng-2926:custom" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2972OverridePluginDependencyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2972OverridePluginDependencyTest.java
@@ -56,7 +56,7 @@ public class MavenITmng2972OverridePluginDependencyTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifact( "org.apache.maven.its.plugins.class-loader", "dep-b", "0.2-mng-2972", "jar" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );
@@ -88,7 +88,7 @@ public class MavenITmng2972OverridePluginDependencyTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifact( "org.apache.maven.its.plugins.class-loader", "dep-b", "9.9-MNG-2972", "jar" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "org.apache.maven.its.plugins:maven-it-plugin-class-loader:2.1-SNAPSHOT:load" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2994SnapshotRangeRepositoryTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng2994SnapshotRangeRepositoryTest.java
@@ -53,7 +53,7 @@ public class MavenITmng2994SnapshotRangeRepositoryTest
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-2994" );
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.deleteArtifacts( "org.apache.maven.its.mng2994" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3012CoreClassImportTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3012CoreClassImportTest.java
@@ -57,7 +57,7 @@ public class MavenITmng3012CoreClassImportTest
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifact( "org.codehaus.plexus", "plexus-utils", "0.1-mng3012", "jar" );
         verifier.deleteArtifact( "org.codehaus.plexus", "plexus-utils", "0.1-mng3012", "pom" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3052DepRepoAggregationTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3052DepRepoAggregationTest.java
@@ -23,7 +23,6 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
-import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
@@ -60,10 +59,9 @@ public class MavenITmng3052DepRepoAggregationTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3052" );
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.filterFile( "repo-d/org/apache/maven/its/mng3052/direct/0.1-SNAPSHOT/template.pom",
-            "repo-d/org/apache/maven/its/mng3052/direct/0.1-SNAPSHOT/direct-0.1-20090517.133956-1.pom", "UTF-8", filterProps );
+            "repo-d/org/apache/maven/its/mng3052/direct/0.1-SNAPSHOT/direct-0.1-20090517.133956-1.pom", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3092SnapshotsExcludedFromVersionRangeTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3092SnapshotsExcludedFromVersionRangeTest.java
@@ -59,7 +59,7 @@ public class MavenITmng3092SnapshotsExcludedFromVersionRangeTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3092" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3099SettingsProfilesWithNoPomTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3099SettingsProfilesWithNoPomTest.java
@@ -57,7 +57,7 @@ public class MavenITmng3099SettingsProfilesWithNoPomTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3099" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "org.apache.maven.its.mng3099:maven-mng3099-plugin:0.1:touch" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3139UseCachedMetadataOfBlacklistedRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3139UseCachedMetadataOfBlacklistedRepoTest.java
@@ -59,7 +59,7 @@ public class MavenITmng3139UseCachedMetadataOfBlacklistedRepoTest
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3139" );
 
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.setLogFileName( "log1.txt" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3217InterPluginDependencyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3217InterPluginDependencyTest.java
@@ -58,7 +58,7 @@ public class MavenITmng3217InterPluginDependencyTest
         verifier.deleteDirectory( "sub-1/target" );
         verifier.deleteDirectory( "sub-2/target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3217" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3220ImportScopeTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3220ImportScopeTest.java
@@ -53,8 +53,7 @@ public class MavenITmng3220ImportScopeTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3220" );
-        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8",
-                             verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );
@@ -74,8 +73,7 @@ public class MavenITmng3220ImportScopeTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3220" );
-        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8",
-                             verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
 

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3284UsingCachedPluginsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3284UsingCachedPluginsTest.java
@@ -60,7 +60,7 @@ public class MavenITmng3284UsingCachedPluginsTest
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3284" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3314OfflineSnapshotsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3314OfflineSnapshotsTest.java
@@ -59,7 +59,7 @@ public class MavenITmng3314OfflineSnapshotsTest
             Verifier verifier = newVerifier( testDir.getAbsolutePath() );
             verifier.deleteArtifacts( "org.apache.maven.its.mng3314" );
             verifier.setLogFileName( "log1.txt" );
-            verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+            verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
             verifier.addCliArgument( "--settings" );
             verifier.addCliArgument( "settings.xml" );
             verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3379ParallelArtifactDownloadsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3379ParallelArtifactDownloadsTest.java
@@ -59,7 +59,7 @@ public class MavenITmng3379ParallelArtifactDownloadsTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng3379.b" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3379.c" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3379.d" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "-Dmaven.artifact.threads=16" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3380ManagedRelocatedTransdepsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3380ManagedRelocatedTransdepsTest.java
@@ -63,7 +63,7 @@ public class MavenITmng3380ManagedRelocatedTransdepsTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3380" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3415JunkRepositoryMetadataTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3415JunkRepositoryMetadataTest.java
@@ -28,7 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.util.Deque;
-import java.util.Properties;
+import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 import org.apache.maven.shared.utils.io.FileUtils;
@@ -96,7 +96,7 @@ public class MavenITmng3415JunkRepositoryMetadataTest
 
         setupDummyDependency( verifier, testDir, true );
 
-        Properties filterProps = verifier.newDefaultFilterProperties();
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
         filterProps.put( "@protocol@", "invalid" );
         filterProps.put( "@port@", "0" );
         File settings = verifier.filterFile( "settings-template.xml", "settings-a.xml", "UTF-8", filterProps );
@@ -199,7 +199,7 @@ public class MavenITmng3415JunkRepositoryMetadataTest
             int port = ( (NetworkConnector) server.getConnectors()[0] ).getLocalPort();
             System.out.println( "Bound server socket to the port " + port );
 
-            Properties filterProps = verifier.newDefaultFilterProperties();
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
             filterProps.put( "@protocol@", "http" );
             filterProps.put( "@port@", Integer.toString( port ) );
             File settings = verifier.filterFile( "settings-template.xml", "settings-b.xml", "UTF-8", filterProps );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3461MirrorMatchingTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3461MirrorMatchingTest.java
@@ -27,7 +27,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Properties;
+import java.util.Map;
 
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
@@ -66,8 +66,7 @@ public class MavenITmng3461MirrorMatchingTest
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3461" );
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );
@@ -140,8 +139,8 @@ public class MavenITmng3461MirrorMatchingTest
 
             verifier.setAutoclean( false );
             verifier.deleteArtifacts( "org.apache.maven.its.mng3461" );
-            Properties filterProps = verifier.newDefaultFilterProperties();
-            filterProps.setProperty( "@test.port@", Integer.toString( port ) );
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
+            filterProps.put( "@test.port@", Integer.toString( port ) );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "--settings" );
             verifier.addCliArgument( "settings.xml" );
@@ -175,8 +174,7 @@ public class MavenITmng3461MirrorMatchingTest
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3461" );
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3470StrictChecksumVerificationOfDependencyPomTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3470StrictChecksumVerificationOfDependencyPomTest.java
@@ -56,7 +56,7 @@ public class MavenITmng3470StrictChecksumVerificationOfDependencyPomTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3470" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         try

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3482DependencyPomInterpolationTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3482DependencyPomInterpolationTest.java
@@ -50,7 +50,7 @@ public class MavenITmng3482DependencyPomInterpolationTest
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3482" );
         verifier.addCliArgument( "-s" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3586SystemScopePluginDependencyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3586SystemScopePluginDependencyTest.java
@@ -59,7 +59,7 @@ public class MavenITmng3586SystemScopePluginDependencyTest
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3586" );
         verifier.getSystemProperties().setProperty( "test.home", testDir.getAbsolutePath() );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3667ResolveDepsWithBadPomVersionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3667ResolveDepsWithBadPomVersionTest.java
@@ -61,7 +61,7 @@ public class MavenITmng3667ResolveDepsWithBadPomVersionTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng3667" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3680InvalidDependencyPOMTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3680InvalidDependencyPOMTest.java
@@ -56,7 +56,7 @@ public class MavenITmng3680InvalidDependencyPOMTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3680" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3714ToolchainsCliOptionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3714ToolchainsCliOptionTest.java
@@ -23,6 +23,7 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
+import java.util.Map;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
@@ -59,8 +60,8 @@ public class MavenITmng3714ToolchainsCliOptionTest
         new File( javaHome, "bin/javac.exe").createNewFile();
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
-        Properties properties = verifier.newDefaultFilterProperties();
-        properties.setProperty( "@javaHome@", javaHome.getAbsolutePath() );
+        Map<String, String> properties = verifier.newDefaultFilterMap();
+        properties.put( "@javaHome@", javaHome.getAbsolutePath() );
 
         verifier.filterFile( "toolchains.xml", "toolchains.xml", "UTF-8", properties );
 

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3769ExclusionRelocatedTransdepsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3769ExclusionRelocatedTransdepsTest.java
@@ -58,7 +58,7 @@ public class MavenITmng3769ExclusionRelocatedTransdepsTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3769" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3775ConflictResolutionBacktrackingTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3775ConflictResolutionBacktrackingTest.java
@@ -99,7 +99,7 @@ public class MavenITmng3775ConflictResolutionBacktrackingTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng3775" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3805ExtensionClassPathOrderingTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3805ExtensionClassPathOrderingTest.java
@@ -57,7 +57,7 @@ public class MavenITmng3805ExtensionClassPathOrderingTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3805" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3813PluginClassPathOrderingTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3813PluginClassPathOrderingTest.java
@@ -57,7 +57,7 @@ public class MavenITmng3813PluginClassPathOrderingTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3813" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3814BogusProjectCycleTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3814BogusProjectCycleTest.java
@@ -55,7 +55,7 @@ public class MavenITmng3814BogusProjectCycleTest
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3814" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3872ProfileActivationInRelocatedPomTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3872ProfileActivationInRelocatedPomTest.java
@@ -24,7 +24,6 @@ import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
 import java.util.List;
-import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
@@ -57,8 +56,7 @@ public class MavenITmng3872ProfileActivationInRelocatedPomTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3872" );
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3890TransitiveDependencyScopeUpdateTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3890TransitiveDependencyScopeUpdateTest.java
@@ -58,7 +58,7 @@ public class MavenITmng3890TransitiveDependencyScopeUpdateTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3890" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3899ExtensionInheritanceTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3899ExtensionInheritanceTest.java
@@ -57,7 +57,7 @@ public class MavenITmng3899ExtensionInheritanceTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3899" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3906MergedPluginClassPathOrderingTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3906MergedPluginClassPathOrderingTest.java
@@ -57,7 +57,7 @@ public class MavenITmng3906MergedPluginClassPathOrderingTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3906" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3948ParentResolutionFromProfileReposTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3948ParentResolutionFromProfileReposTest.java
@@ -57,7 +57,7 @@ public class MavenITmng3948ParentResolutionFromProfileReposTest
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3948" );
-        verifier.filterFile( "pom.xml", "pom.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "pom.xml", "pom.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3970DepResolutionFromProfileReposTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3970DepResolutionFromProfileReposTest.java
@@ -57,7 +57,7 @@ public class MavenITmng3970DepResolutionFromProfileReposTest
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3970" );
-        verifier.filterFile( "pom.xml", "pom.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "pom.xml", "pom.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();
@@ -79,7 +79,7 @@ public class MavenITmng3970DepResolutionFromProfileReposTest
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3970" );
-        verifier.filterFile( "settings.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3974MirrorOrderingTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3974MirrorOrderingTest.java
@@ -56,7 +56,7 @@ public class MavenITmng3974MirrorOrderingTest
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3974" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3983PluginResolutionFromProfileReposTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3983PluginResolutionFromProfileReposTest.java
@@ -59,7 +59,7 @@ public class MavenITmng3983PluginResolutionFromProfileReposTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3983" );
-        verifier.filterFile( "pom.xml", "pom.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "pom.xml", "pom.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();
@@ -83,7 +83,7 @@ public class MavenITmng3983PluginResolutionFromProfileReposTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng3983" );
-        verifier.filterFile( "settings.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4036ParentResolutionFromSettingsRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4036ParentResolutionFromSettingsRepoTest.java
@@ -53,7 +53,7 @@ public class MavenITmng4036ParentResolutionFromSettingsRepoTest
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
-        verifier.filterFile( "settings.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings.xml", "settings.xml", "UTF-8" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4036" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4068AuthenticatedMirrorTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4068AuthenticatedMirrorTest.java
@@ -23,7 +23,8 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
-import java.util.Properties;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
@@ -128,8 +129,8 @@ public class MavenITmng4068AuthenticatedMirrorTest
     public void testit()
         throws Exception
     {
-        Properties filterProps = new Properties();
-        filterProps.setProperty( "@mirrorPort@", Integer.toString( port ) );
+        Map<String, String> filterProps = new HashMap<>();
+        filterProps.put( "@mirrorPort@", Integer.toString( port ) );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4070WhitespaceTrimmingTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4070WhitespaceTrimmingTest.java
@@ -57,7 +57,7 @@ public class MavenITmng4070WhitespaceTrimmingTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4070" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4072InactiveProfileReposTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4072InactiveProfileReposTest.java
@@ -23,7 +23,6 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
-import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
@@ -55,10 +54,9 @@ public class MavenITmng4072InactiveProfileReposTest
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4072" );
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8", filterProps );
-        verifier.filterFile( "profiles-template.xml", "profiles.xml", "UTF-8", filterProps );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
+        verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8" );
+        verifier.filterFile( "profiles-template.xml", "profiles.xml", "UTF-8" );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         try

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4087PercentEncodedFileUrlTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4087PercentEncodedFileUrlTest.java
@@ -55,7 +55,7 @@ public class MavenITmng4087PercentEncodedFileUrlTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4087" );
-        verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4150VersionRangeTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4150VersionRangeTest.java
@@ -56,7 +56,7 @@ public class MavenITmng4150VersionRangeTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4150" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4166HideCoreCommonsCliTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4166HideCoreCommonsCliTest.java
@@ -59,7 +59,7 @@ public class MavenITmng4166HideCoreCommonsCliTest
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifact( "commons-cli", "commons-cli", "0.1.4166", "jar" );
         verifier.deleteArtifact( "commons-cli", "commons-cli", "0.1.4166", "pom" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4180PerDependencyExclusionsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4180PerDependencyExclusionsTest.java
@@ -59,7 +59,7 @@ public class MavenITmng4180PerDependencyExclusionsTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4180" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4189UniqueVersionSnapshotTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4189UniqueVersionSnapshotTest.java
@@ -50,7 +50,7 @@ public class MavenITmng4189UniqueVersionSnapshotTest
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4189" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
 
         // depend on org.apache.maven.its.mng4189:dep:1.0-20090608.090416-1:jar
         verifier = newVerifier( testDir.getAbsolutePath() );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4190MirrorRepoMergingTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4190MirrorRepoMergingTest.java
@@ -61,7 +61,7 @@ public class MavenITmng4190MirrorRepoMergingTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4190" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4199CompileMeetsRuntimeScopeTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4199CompileMeetsRuntimeScopeTest.java
@@ -24,7 +24,6 @@ import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
 import java.util.List;
-import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
@@ -64,9 +63,8 @@ public class MavenITmng4199CompileMeetsRuntimeScopeTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4199" );
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8", filterProps );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
+        verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8" );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4203TransitiveDependencyExclusionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4203TransitiveDependencyExclusionTest.java
@@ -58,7 +58,7 @@ public class MavenITmng4203TransitiveDependencyExclusionTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4203" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4214MirroredParentSearchReposTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4214MirroredParentSearchReposTest.java
@@ -57,7 +57,7 @@ public class MavenITmng4214MirroredParentSearchReposTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4214" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4231SnapshotUpdatePolicyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4231SnapshotUpdatePolicyTest.java
@@ -23,6 +23,7 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
+import java.util.Map;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
@@ -58,17 +59,17 @@ public class MavenITmng4231SnapshotUpdatePolicyTest
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
 
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        filterProps.setProperty( "@updates@", "always" );
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
+        filterProps.put( "@updates@", "always" );
 
-        filterProps.setProperty( "@repo@", "repo-1" );
+        filterProps.put( "@repo@", "repo-1" );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
         verifier.setLogFileName( "log-always-1.txt" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        filterProps.setProperty( "@repo@", "repo-2" );
+        filterProps.put( "@repo@", "repo-2" );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
         verifier.setLogFileName( "log-always-2.txt" );
         verifier.deleteDirectory( "target" );
@@ -99,17 +100,17 @@ public class MavenITmng4231SnapshotUpdatePolicyTest
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
 
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        filterProps.setProperty( "@updates@", "never" );
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
+        filterProps.put( "@updates@", "never" );
 
-        filterProps.setProperty( "@repo@", "repo-1" );
+        filterProps.put( "@repo@", "repo-1" );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
         verifier.setLogFileName( "log-never-1.txt" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();
 
-        filterProps.setProperty( "@repo@", "repo-2" );
+        filterProps.put( "@repo@", "repo-2" );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
         verifier.setLogFileName( "log-never-2.txt" );
         verifier.deleteDirectory( "target" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4235HttpAuthDeploymentChecksumsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4235HttpAuthDeploymentChecksumsTest.java
@@ -30,7 +30,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Deque;
-import java.util.Properties;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 import org.apache.maven.it.utils.DeployedResource;
@@ -143,8 +144,8 @@ public class MavenITmng4235HttpAuthDeploymentChecksumsTest
     public void testit()
         throws Exception
     {
-        Properties filterProps = new Properties();
-        filterProps.setProperty( "@port@", Integer.toString( port ) );
+        Map<String, String> filterProps = new HashMap<>();
+        filterProps.put( "@port@", Integer.toString( port ) );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8", filterProps );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4269BadReactorResolutionFromOutDirTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4269BadReactorResolutionFromOutDirTest.java
@@ -60,7 +60,7 @@ public class MavenITmng4269BadReactorResolutionFromOutDirTest
         // NOTE: It's a crucial prerequisite to create the output directory, i.e. the bad choice
         new File( testDir, "target/classes" ).mkdirs();
         verifier.deleteArtifacts( "org.apache.maven.its.mng4269" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
         // This should use the previous installation/deployment from the repo, not the invalid output directory

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4274PluginRealmArtifactsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4274PluginRealmArtifactsTest.java
@@ -61,7 +61,7 @@ public class MavenITmng4274PluginRealmArtifactsTest
         verifier.deleteArtifact( "org.apache.maven", "maven-core", "2.0.4274", "pom" );
         verifier.deleteArtifact( "org.codehaus.plexus", "plexus-utils", "1.1.4274", "jar" );
         verifier.deleteArtifact( "org.codehaus.plexus", "plexus-utils", "1.1.4274", "pom" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4275RelocationWarningTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4275RelocationWarningTest.java
@@ -56,7 +56,7 @@ public class MavenITmng4275RelocationWarningTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4275" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4276WrongTransitivePlexusUtilsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4276WrongTransitivePlexusUtilsTest.java
@@ -59,7 +59,7 @@ public class MavenITmng4276WrongTransitivePlexusUtilsTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4276" );
         verifier.deleteArtifact( "org.codehaus.plexus", "plexus-utils", "1.1.4276", "jar" );
         verifier.deleteArtifact( "org.codehaus.plexus", "plexus-utils", "1.1.4276", "pom" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4281PreferLocalSnapshotTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4281PreferLocalSnapshotTest.java
@@ -68,7 +68,7 @@ public class MavenITmng4281PreferLocalSnapshotTest
         verifier.setAutoclean( false );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4293RequiresCompilePlusRuntimeScopeTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4293RequiresCompilePlusRuntimeScopeTest.java
@@ -24,7 +24,6 @@ import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
 import java.util.List;
-import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
@@ -61,9 +60,8 @@ public class MavenITmng4293RequiresCompilePlusRuntimeScopeTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4293" );
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8", filterProps );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
+        verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8" );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4317PluginVersionResolutionFromMultiReposTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4317PluginVersionResolutionFromMultiReposTest.java
@@ -58,7 +58,7 @@ public class MavenITmng4317PluginVersionResolutionFromMultiReposTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4317" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "org.apache.maven.its.mng4317:maven-mng4317-plugin:touch" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4320AggregatorAndDependenciesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4320AggregatorAndDependenciesTest.java
@@ -59,7 +59,7 @@ public class MavenITmng4320AggregatorAndDependenciesTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4320" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "org.apache.maven.its.plugins:maven-it-plugin-dependency-resolution:aggregate-test" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4326LocalSnapshotSuppressesRemoteCheckTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4326LocalSnapshotSuppressesRemoteCheckTest.java
@@ -31,7 +31,7 @@ import java.io.PrintWriter;
 import java.util.Date;
 import java.util.Deque;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 import org.eclipse.jetty.server.Handler;
@@ -154,8 +154,8 @@ public class MavenITmng4326LocalSnapshotSuppressesRemoteCheckTest
             // test 1: resolve snapshot, just built local copy should suppress daily remote update check
             verifier = newVerifier( new File( testDir, "test" ).getAbsolutePath() );
             verifier.setAutoclean( false );
-            Properties filterProps = verifier.newDefaultFilterProperties();
-            filterProps.setProperty( "@port@", Integer.toString( port ) );
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
+            filterProps.put( "@port@", Integer.toString( port ) );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "--settings" );
             verifier.addCliArgument( "settings.xml" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4335SettingsOfflineModeTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4335SettingsOfflineModeTest.java
@@ -58,7 +58,7 @@ public class MavenITmng4335SettingsOfflineModeTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4335" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         try
         {
             verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4343MissingReleaseUpdatePolicyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4343MissingReleaseUpdatePolicyTest.java
@@ -30,7 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Deque;
-import java.util.Properties;
+import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 import org.eclipse.jetty.server.Handler;
@@ -156,9 +156,9 @@ public class MavenITmng4343MissingReleaseUpdatePolicyTest
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
 
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        filterProps.setProperty( "@updates@", "always" );
-        filterProps.setProperty( "@port@", Integer.toString( port ) );
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
+        filterProps.put( "@updates@", "always" );
+        filterProps.put( "@port@", Integer.toString( port ) );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
 
         blockAccess = true;
@@ -212,9 +212,9 @@ public class MavenITmng4343MissingReleaseUpdatePolicyTest
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
 
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        filterProps.setProperty( "@updates@", "never" );
-        filterProps.setProperty( "@port@", Integer.toString( port ) );
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
+        filterProps.put( "@updates@", "never" );
+        filterProps.put( "@port@", Integer.toString( port ) );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
 
         blockAccess = true;

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4347ImportScopeWithSettingsProfilesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4347ImportScopeWithSettingsProfilesTest.java
@@ -63,7 +63,7 @@ public class MavenITmng4347ImportScopeWithSettingsProfilesTest
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
 
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
 
         verifier.addCliArgument( "validate" );
         verifier.execute();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4348NoUnnecessaryRepositoryAccessTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4348NoUnnecessaryRepositoryAccessTest.java
@@ -29,7 +29,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
@@ -104,8 +104,8 @@ public class MavenITmng4348NoUnnecessaryRepositoryAccessTest
             verifier.setAutoclean( false );
             verifier.deleteArtifacts( "org.apache.maven.its.mng4348" );
             verifier.deleteDirectory( "target" );
-            Properties filterProps = verifier.newDefaultFilterProperties();
-            filterProps.setProperty( "@port@", Integer.toString( port ) );
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
+            filterProps.put( "@port@", Integer.toString( port ) );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "--settings" );
             verifier.addCliArgument( "settings.xml" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4349RelocatedArtifactWithInvalidPomTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4349RelocatedArtifactWithInvalidPomTest.java
@@ -58,7 +58,7 @@ public class MavenITmng4349RelocatedArtifactWithInvalidPomTest
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4349" );
         verifier.deleteDirectory( "target" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4353PluginDependencyResolutionFromPomRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4353PluginDependencyResolutionFromPomRepoTest.java
@@ -23,6 +23,7 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
+import java.util.Map;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
@@ -56,7 +57,7 @@ public class MavenITmng4353PluginDependencyResolutionFromPomRepoTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4353" );
-        Properties filterProps = verifier.newDefaultFilterProperties();
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
         verifier.filterFile( "repo-1/org/apache/maven/its/mng4353/maven-mng4353-plugin/0.1/template.pom",
                              "repo-1/org/apache/maven/its/mng4353/maven-mng4353-plugin/0.1/maven-mng4353-plugin-0.1"

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4355ExtensionAutomaticVersionResolutionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4355ExtensionAutomaticVersionResolutionTest.java
@@ -23,7 +23,6 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
-import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
@@ -56,8 +55,7 @@ public class MavenITmng4355ExtensionAutomaticVersionResolutionTest
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4355" );
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4357LifecycleMappingDiscoveryInReactorTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4357LifecycleMappingDiscoveryInReactorTest.java
@@ -23,7 +23,6 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
-import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
@@ -59,8 +58,7 @@ public class MavenITmng4357LifecycleMappingDiscoveryInReactorTest
         verifier.deleteDirectory( "mod-a/target" );
         verifier.deleteDirectory( "mod-b/target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4357" );
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4360WebDavSupportTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4360WebDavSupportTest.java
@@ -29,7 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
@@ -138,8 +138,8 @@ public class MavenITmng4360WebDavSupportTest
             verifier.setAutoclean( false );
             verifier.deleteArtifacts( "org.apache.maven.its.mng4360" );
             verifier.deleteDirectory( "target" );
-            Properties filterProps = verifier.newDefaultFilterProperties();
-            filterProps.setProperty( "@port@", Integer.toString( port ) );
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
+            filterProps.put( "@port@", Integer.toString( port ) );
             verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "--settings" );
             verifier.addCliArgument( "settings.xml" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4361ForceDependencySnapshotUpdateTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4361ForceDependencySnapshotUpdateTest.java
@@ -23,6 +23,7 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
+import java.util.Map;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
@@ -59,9 +60,9 @@ public class MavenITmng4361ForceDependencySnapshotUpdateTest
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
 
-        Properties filterProps = verifier.newDefaultFilterProperties();
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
 
-        filterProps.setProperty( "@repo@", "repo-1" );
+        filterProps.put( "@repo@", "repo-1" );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
         verifier.setLogFileName( "log-force-1.txt" );
         verifier.addCliArgument( "validate" );
@@ -70,7 +71,7 @@ public class MavenITmng4361ForceDependencySnapshotUpdateTest
 
         assertNull( verifier.loadProperties( "target/checksum.properties" ).getProperty( "b-0.1-SNAPSHOT.jar" ) );
 
-        filterProps.setProperty( "@repo@", "repo-2" );
+        filterProps.put( "@repo@", "repo-2" );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
         verifier.setLogFileName( "log-force-2.txt" );
         verifier.deleteDirectory( "target" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4363DynamicAdditionOfDependencyArtifactTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4363DynamicAdditionOfDependencyArtifactTest.java
@@ -59,7 +59,7 @@ public class MavenITmng4363DynamicAdditionOfDependencyArtifactTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4363" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "generate-sources" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4367LayoutAwareMirrorSelectionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4367LayoutAwareMirrorSelectionTest.java
@@ -23,7 +23,7 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
-import java.util.Properties;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -57,10 +57,10 @@ public class MavenITmng4367LayoutAwareMirrorSelectionTest
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4367" );
 
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        filterProps.setProperty( "@repourl@", filterProps.getProperty( "@baseurl@" ) + "/void" );
-        filterProps.setProperty( "@mirrorurl@", filterProps.getProperty( "@baseurl@" ) + "/repo" );
-        filterProps.setProperty( "@layouts@", "" );
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
+        filterProps.put( "@repourl@", filterProps.get( "@baseurl@" ) + "/void" );
+        filterProps.put( "@mirrorurl@", filterProps.get( "@baseurl@" ) + "/repo" );
+        filterProps.put( "@layouts@", "" );
 
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings-a.xml" );
@@ -88,10 +88,10 @@ public class MavenITmng4367LayoutAwareMirrorSelectionTest
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4367" );
 
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        filterProps.setProperty( "@repourl@", filterProps.getProperty( "@baseurl@" ) + "/void" );
-        filterProps.setProperty( "@mirrorurl@", filterProps.getProperty( "@baseurl@" ) + "/repo" );
-        filterProps.setProperty( "@layouts@", "default,legacy" );
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
+        filterProps.put( "@repourl@", filterProps.get( "@baseurl@" ) + "/void" );
+        filterProps.put( "@mirrorurl@", filterProps.get( "@baseurl@" ) + "/repo" );
+        filterProps.put( "@layouts@", "default,legacy" );
 
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings-b.xml" );
@@ -119,10 +119,10 @@ public class MavenITmng4367LayoutAwareMirrorSelectionTest
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4367" );
 
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        filterProps.setProperty( "@repourl@", filterProps.getProperty( "@baseurl@" ) + "/repo" );
-        filterProps.setProperty( "@mirrorurl@", filterProps.getProperty( "@baseurl@" ) + "/void" );
-        filterProps.setProperty( "@layouts@", "foo" );
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
+        filterProps.put( "@repourl@", filterProps.get( "@baseurl@" ) + "/repo" );
+        filterProps.put( "@mirrorurl@", filterProps.get( "@baseurl@" ) + "/void" );
+        filterProps.put( "@layouts@", "foo" );
 
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings-c.xml" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4379TransitiveSystemPathInterpolatedWithEnvVarTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4379TransitiveSystemPathInterpolatedWithEnvVarTest.java
@@ -57,7 +57,7 @@ public class MavenITmng4379TransitiveSystemPathInterpolatedWithEnvVarTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4379" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.setEnvironmentVariable( "MNG_4379_HOME", testDir.getAbsolutePath() );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4393ParseExternalParenPomLenientTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4393ParseExternalParenPomLenientTest.java
@@ -55,7 +55,7 @@ public class MavenITmng4393ParseExternalParenPomLenientTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4393" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4400RepositoryOrderTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4400RepositoryOrderTest.java
@@ -55,7 +55,7 @@ public class MavenITmng4400RepositoryOrderTest
         Verifier verifier = newVerifier( new File( testDir, "settings" ).getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4400" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );
@@ -80,7 +80,7 @@ public class MavenITmng4400RepositoryOrderTest
         Verifier verifier = newVerifier( new File( testDir, "pom" ).getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4400" );
-        verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4401RepositoryOrderForParentPomTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4401RepositoryOrderForParentPomTest.java
@@ -56,7 +56,7 @@ public class MavenITmng4401RepositoryOrderForParentPomTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4401" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4403LenientDependencyPomParsingTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4403LenientDependencyPomParsingTest.java
@@ -60,7 +60,7 @@ public class MavenITmng4403LenientDependencyPomParsingTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4403" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4412OfflineModeInPluginTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4412OfflineModeInPluginTest.java
@@ -57,7 +57,7 @@ public class MavenITmng4412OfflineModeInPluginTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4412" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "-Presolver" );
         verifier.addCliArgument( "--offline" );
         verifier.addCliArgument( "-s" );
@@ -92,7 +92,7 @@ public class MavenITmng4412OfflineModeInPluginTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4412" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "-Pcollector" );
         verifier.addCliArgument( "--offline" );
         verifier.addCliArgument( "-s" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4413MirroringOfDependencyRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4413MirroringOfDependencyRepoTest.java
@@ -23,7 +23,7 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
-import java.util.Properties;
+import java.util.Map;
 
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
@@ -109,8 +109,8 @@ public class MavenITmng4413MirroringOfDependencyRepoTest
             verifier.setAutoclean( false );
             verifier.deleteDirectory( "target" );
             verifier.deleteArtifacts( "org.apache.maven.its.mng4413" );
-            Properties filterProps = verifier.newDefaultFilterProperties();
-            filterProps.setProperty( "@port@", Integer.toString( port ) );
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
+            filterProps.put( "@port@", Integer.toString( port ) );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "-s" );
             verifier.addCliArgument( "settings.xml" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4428FollowHttpRedirectTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4428FollowHttpRedirectTest.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import org.eclipse.jetty.server.Connector;
@@ -137,9 +138,9 @@ public class MavenITmng4428FollowHttpRedirectTest
             verifier.setAutoclean( false );
             verifier.deleteArtifacts( "org.apache.maven.its.mng4428" );
             verifier.deleteDirectory( "target" );
-            Properties filterProps = verifier.newDefaultFilterProperties();
-            filterProps.setProperty( "@protocol@", fromHttp ? "http" : "https" );
-            filterProps.setProperty( "@port@", Integer.toString( ( (NetworkConnector) from ).getLocalPort() ) );
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
+            filterProps.put( "@protocol@", fromHttp ? "http" : "https" );
+            filterProps.put( "@port@", Integer.toString( ( (NetworkConnector) from ).getLocalPort() ) );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "-X" );
             verifier.addCliArgument( "--settings" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4433ForceParentSnapshotUpdateTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4433ForceParentSnapshotUpdateTest.java
@@ -23,7 +23,7 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
-import java.util.Properties;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -58,9 +58,9 @@ public class MavenITmng4433ForceParentSnapshotUpdateTest
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
 
-        Properties filterProps = verifier.newDefaultFilterProperties();
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
 
-        filterProps.setProperty( "@repo@", "repo-1" );
+        filterProps.put( "@repo@", "repo-1" );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
         verifier.setLogFileName( "log-force-1.txt" );
         verifier.deleteDirectory( "target" );
@@ -71,7 +71,7 @@ public class MavenITmng4433ForceParentSnapshotUpdateTest
         verifier.verifyFilePresent( "target/old.txt" );
         verifier.verifyFileNotPresent( "target/new.txt" );
 
-        filterProps.setProperty( "@repo@", "repo-2" );
+        filterProps.put( "@repo@", "repo-2" );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
         verifier.setLogFileName( "log-force-2.txt" );
         verifier.deleteDirectory( "target" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4452ResolutionOfSnapshotWithClassifierTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4452ResolutionOfSnapshotWithClassifierTest.java
@@ -84,7 +84,7 @@ public class MavenITmng4452ResolutionOfSnapshotWithClassifierTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4452" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4465PluginPrefixFromLocalCacheOfDownRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4465PluginPrefixFromLocalCacheOfDownRepoTest.java
@@ -59,7 +59,7 @@ public class MavenITmng4465PluginPrefixFromLocalCacheOfDownRepoTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4465" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.setLogFileName( "log1.txt" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4482ForcePluginSnapshotUpdateTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4482ForcePluginSnapshotUpdateTest.java
@@ -23,6 +23,7 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
+import java.util.Map;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
@@ -64,9 +65,9 @@ public class MavenITmng4482ForcePluginSnapshotUpdateTest
          */
         verifier.setForkJvm( true );
 
-        Properties filterProps = verifier.newDefaultFilterProperties();
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
 
-        filterProps.setProperty( "@repo@", "repo-1" );
+        filterProps.put( "@repo@", "repo-1" );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
         verifier.setLogFileName( "log-force-1.txt" );
         verifier.deleteDirectory( "target" );
@@ -78,7 +79,7 @@ public class MavenITmng4482ForcePluginSnapshotUpdateTest
         assertEquals( "old", props1.getProperty( "one" ) );
         assertNull( props1.getProperty( "two" ) );
 
-        filterProps.setProperty( "@repo@", "repo-2" );
+        filterProps.put( "@repo@", "repo-2" );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
         verifier.setLogFileName( "log-force-2.txt" );
         verifier.deleteDirectory( "target" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4488ValidateExternalParenPomLenientTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4488ValidateExternalParenPomLenientTest.java
@@ -55,7 +55,7 @@ public class MavenITmng4488ValidateExternalParenPomLenientTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4488" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4489MirroringOfExtensionRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4489MirroringOfExtensionRepoTest.java
@@ -23,7 +23,7 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
-import java.util.Properties;
+import java.util.Map;
 
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
@@ -109,8 +109,8 @@ public class MavenITmng4489MirroringOfExtensionRepoTest
             verifier.setAutoclean( false );
             verifier.deleteDirectory( "target" );
             verifier.deleteArtifacts( "org.apache.maven.its.mng4489" );
-            Properties filterProps = verifier.newDefaultFilterProperties();
-            filterProps.setProperty( "@port@", Integer.toString( port ) );
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
+            filterProps.put( "@port@", Integer.toString( port ) );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "-s" );
             verifier.addCliArgument( "settings.xml" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4498IgnoreBrokenMetadataTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4498IgnoreBrokenMetadataTest.java
@@ -56,7 +56,7 @@ public class MavenITmng4498IgnoreBrokenMetadataTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4498" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4500NoUpdateOfTimestampedSnapshotsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4500NoUpdateOfTimestampedSnapshotsTest.java
@@ -29,7 +29,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Request;
@@ -105,8 +105,8 @@ public class MavenITmng4500NoUpdateOfTimestampedSnapshotsTest
             verifier.setAutoclean( false );
             verifier.deleteDirectory( "target" );
             verifier.deleteArtifacts( "org.apache.maven.its.mng4500" );
-            Properties filterProps = verifier.newDefaultFilterProperties();
-            filterProps.setProperty( "@port@", Integer.toString( port ) );
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
+            filterProps.put( "@port@", Integer.toString( port ) );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "-s" );
             verifier.addCliArgument( "settings.xml" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4522FailUponMissingDependencyParentPomTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4522FailUponMissingDependencyParentPomTest.java
@@ -56,7 +56,7 @@ public class MavenITmng4522FailUponMissingDependencyParentPomTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4522" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         try

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4526MavenProjectArtifactsScopeTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4526MavenProjectArtifactsScopeTest.java
@@ -57,7 +57,7 @@ public class MavenITmng4526MavenProjectArtifactsScopeTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4526" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "generate-sources" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4553CoreArtifactFilterConsidersGroupIdTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4553CoreArtifactFilterConsidersGroupIdTest.java
@@ -56,7 +56,7 @@ public class MavenITmng4553CoreArtifactFilterConsidersGroupIdTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4553" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4554PluginPrefixMappingUpdateTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4554PluginPrefixMappingUpdateTest.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import org.apache.maven.shared.utils.io.FileUtils;
 import org.eclipse.jetty.server.NetworkConnector;
@@ -112,10 +112,10 @@ public class MavenITmng4554PluginPrefixMappingUpdateTest
                 // expected when running test on Windows using embedded Maven (JAR files locked by plugin class realm)
                 assertFalse( new File( verifier.getArtifactMetadataPath( "org.apache.maven.its.mng4554", null, null, "maven-metadata-mng4554.xml" ) ).exists() );
             }
-            Properties filterProps = verifier.newDefaultFilterProperties();
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
             NetworkConnector connector = (NetworkConnector) server.getConnectors()[0];
-            filterProps.setProperty( "@port@", Integer.toString( connector.getLocalPort() ) );
-            filterProps.setProperty( "@repo@", "repo-1" );
+            filterProps.put( "@port@", Integer.toString( connector.getLocalPort() ) );
+            filterProps.put( "@repo@", "repo-1" );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "-s" );
             verifier.addCliArgument( "settings.xml" );
@@ -200,10 +200,10 @@ public class MavenITmng4554PluginPrefixMappingUpdateTest
                 // expected when running test on Windows using embedded Maven (JAR files locked by plugin class realm)
                 assertFalse( new File( verifier.getArtifactMetadataPath( "org.apache.maven.its.mng4554", null, null, "maven-metadata-mng4554.xml" ) ).exists() );
             }
-            Properties filterProps = verifier.newDefaultFilterProperties();
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
             NetworkConnector connector = (NetworkConnector) server.getConnectors()[0];
-            filterProps.setProperty( "@port@", Integer.toString( connector.getLocalPort() ) );
-            filterProps.setProperty( "@repo@", "repo-1" );
+            filterProps.put( "@port@", Integer.toString( connector.getLocalPort() ) );
+            filterProps.put( "@repo@", "repo-1" );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "-U" );
             verifier.addCliArgument( "-s" );
@@ -291,10 +291,10 @@ public class MavenITmng4554PluginPrefixMappingUpdateTest
                 // expected when running test on Windows using embedded Maven (JAR files locked by plugin class realm)
                 assertFalse( new File( verifier.getArtifactMetadataPath( "org.apache.maven.its.mng4554", null, null, "maven-metadata-mng4554.xml" ) ).exists() );
             }
-            Properties filterProps = verifier.newDefaultFilterProperties();
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
             NetworkConnector connector = (NetworkConnector) server.getConnectors()[0];
-            filterProps.setProperty( "@port@", Integer.toString( connector.getLocalPort() ) );
-            filterProps.setProperty( "@repo@", "repo-it" );
+            filterProps.put( "@port@", Integer.toString( connector.getLocalPort() ) );
+            filterProps.put( "@repo@", "repo-it" );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "-s" );
             verifier.addCliArgument( "settings.xml" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4555MetaversionResolutionOfflineTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4555MetaversionResolutionOfflineTest.java
@@ -28,7 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.File;
 import java.util.Deque;
-import java.util.Properties;
+import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 import org.eclipse.jetty.server.Handler;
@@ -99,8 +99,8 @@ public class MavenITmng4555MetaversionResolutionOfflineTest
             }
             int port = ( (NetworkConnector) server.getConnectors()[0] ).getLocalPort();
             System.out.println( "Bound server socket to the port " + port );
-            Properties filterProps = verifier.newDefaultFilterProperties();
-            filterProps.setProperty( "@port@", Integer.toString( port ) );
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
+            filterProps.put( "@port@", Integer.toString( port ) );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "--offline" );
             verifier.addCliArgument( "--settings" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4561MirroringOfPluginRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4561MirroringOfPluginRepoTest.java
@@ -23,7 +23,7 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
-import java.util.Properties;
+import java.util.Map;
 
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
@@ -109,8 +109,8 @@ public class MavenITmng4561MirroringOfPluginRepoTest
             verifier.setAutoclean( false );
             verifier.deleteDirectory( "target" );
             verifier.deleteArtifacts( "org.apache.maven.its.mng4561" );
-            Properties filterProps = verifier.newDefaultFilterProperties();
-            filterProps.setProperty( "@port@", Integer.toString( port ) );
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
+            filterProps.put( "@port@", Integer.toString( port ) );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "-s" );
             verifier.addCliArgument( "settings.xml" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4586PluginPrefixResolutionFromVersionlessPluginMgmtTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4586PluginPrefixResolutionFromVersionlessPluginMgmtTest.java
@@ -56,7 +56,7 @@ public class MavenITmng4586PluginPrefixResolutionFromVersionlessPluginMgmtTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4586" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "mng4586:touch" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4590ImportedPomUsesSystemAndUserPropertiesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4590ImportedPomUsesSystemAndUserPropertiesTest.java
@@ -56,7 +56,7 @@ public class MavenITmng4590ImportedPomUsesSystemAndUserPropertiesTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4590" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.setEnvironmentVariable( "MAVEN_OPTS", "-Dtest.file=pom.xml" );
         verifier.addCliArgument( "-Dtest.dir=" + testDir.getAbsolutePath() );
         verifier.addCliArgument( "--settings" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4600DependencyOptionalFlagManagementTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4600DependencyOptionalFlagManagementTest.java
@@ -82,7 +82,7 @@ public class MavenITmng4600DependencyOptionalFlagManagementTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4600" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4654ArtifactHandlerForMainArtifactTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4654ArtifactHandlerForMainArtifactTest.java
@@ -56,7 +56,7 @@ public class MavenITmng4654ArtifactHandlerForMainArtifactTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4654" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4666CoreRealmImportTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4666CoreRealmImportTest.java
@@ -77,7 +77,7 @@ public class MavenITmng4666CoreRealmImportTest
         verifier.deleteArtifacts( "org.sonatype.sisu", "sisu-inject-plexus", "0.1-stub" );
         verifier.deleteArtifacts( "org.sonatype.spice", "spice-inject-plexus", "0.1-stub" );
         verifier.deleteArtifacts( "classworlds", "classworlds", "0.1-stub" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4679SnapshotUpdateInPluginTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4679SnapshotUpdateInPluginTest.java
@@ -23,7 +23,7 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
-import java.util.Properties;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -59,9 +59,9 @@ public class MavenITmng4679SnapshotUpdateInPluginTest
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
 
-        Properties filterProps = verifier.newDefaultFilterProperties();
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
 
-        filterProps.setProperty( "@repo@", "repo-1" );
+        filterProps.put( "@repo@", "repo-1" );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
         verifier.setLogFileName( "log-force-1.txt" );
         verifier.addCliArgument( "validate" );
@@ -71,7 +71,7 @@ public class MavenITmng4679SnapshotUpdateInPluginTest
         assertChecksum( verifier, "jar", "2ea5c3d713bbaba7b87746449b91cd00e876703d" );
         assertChecksum( verifier, "pom", "0b58dbbc61f81b85a70692ffdce88cf1892a8da4" );
 
-        filterProps.setProperty( "@repo@", "repo-2" );
+        filterProps.put( "@repo@", "repo-2" );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
         verifier.setLogFileName( "log-force-2.txt" );
         verifier.deleteDirectory( "target" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4690InterdependentConflictResolutionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4690InterdependentConflictResolutionTest.java
@@ -102,7 +102,7 @@ public class MavenITmng4690InterdependentConflictResolutionTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4690" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4696MavenProjectDependencyArtifactsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4696MavenProjectDependencyArtifactsTest.java
@@ -60,7 +60,7 @@ public class MavenITmng4696MavenProjectDependencyArtifactsTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4696" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "initialize" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4720DependencyManagementExclusionMergeTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4720DependencyManagementExclusionMergeTest.java
@@ -58,7 +58,7 @@ public class MavenITmng4720DependencyManagementExclusionMergeTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4720" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4721OptionalPluginDependencyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4721OptionalPluginDependencyTest.java
@@ -57,7 +57,7 @@ public class MavenITmng4721OptionalPluginDependencyTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4721" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4729MirrorProxyAuthUsedByProjectBuilderTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4729MirrorProxyAuthUsedByProjectBuilderTest.java
@@ -23,6 +23,7 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
+import java.util.Map;
 import java.util.Properties;
 
 import org.eclipse.jetty.security.ConstraintMapping;
@@ -109,8 +110,8 @@ public class MavenITmng4729MirrorProxyAuthUsedByProjectBuilderTest
             verifier.setAutoclean( false );
             verifier.deleteDirectory( "target" );
             verifier.deleteArtifacts( "org.apache.maven.its.mng4729" );
-            Properties filterProps = verifier.newDefaultFilterProperties();
-            filterProps.setProperty( "@port@", Integer.toString( port ) );
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
+            filterProps.put( "@port@", Integer.toString( port ) );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "-s" );
             verifier.addCliArgument( "settings.xml" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4745PluginVersionUpdateTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4745PluginVersionUpdateTest.java
@@ -23,6 +23,7 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
+import java.util.Map;
 import java.util.Properties;
 
 import org.apache.maven.shared.utils.io.FileUtils;
@@ -59,8 +60,8 @@ public class MavenITmng4745PluginVersionUpdateTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4745" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        filterProps.setProperty( "@updates@", "always" );
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
+        filterProps.put( "@updates@", "always" );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
 
         writeMetadata( testDir, "1.0", "20100729123455" );
@@ -96,8 +97,8 @@ public class MavenITmng4745PluginVersionUpdateTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4745" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        filterProps.setProperty( "@updates@", "never" );
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
+        filterProps.put( "@updates@", "never" );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
 
         writeMetadata( testDir, "1.0", "20100729123455" );
@@ -134,8 +135,8 @@ public class MavenITmng4745PluginVersionUpdateTest
         verifier.addCliArgument( "-U" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        filterProps.setProperty( "@updates@", "never" );
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
+        filterProps.put( "@updates@", "never" );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
 
         writeMetadata( testDir, "1.0", "20100729123455" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4750ResolvedMavenProjectDependencyArtifactsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4750ResolvedMavenProjectDependencyArtifactsTest.java
@@ -59,7 +59,7 @@ public class MavenITmng4750ResolvedMavenProjectDependencyArtifactsTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4750" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "initialize" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4755FetchRemoteMetadataForVersionRangeTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4755FetchRemoteMetadataForVersionRangeTest.java
@@ -68,7 +68,7 @@ public class MavenITmng4755FetchRemoteMetadataForVersionRangeTest
         verifier.deleteDirectory( "target" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4761PluginLevelDependencyScopesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4761PluginLevelDependencyScopesTest.java
@@ -61,7 +61,7 @@ public class MavenITmng4761PluginLevelDependencyScopesTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4761" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4768NearestMatchConflictResolutionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4768NearestMatchConflictResolutionTest.java
@@ -103,7 +103,7 @@ public class MavenITmng4768NearestMatchConflictResolutionTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4768" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4771PluginPrefixResolutionDoesntTouchDisabledRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4771PluginPrefixResolutionDoesntTouchDisabledRepoTest.java
@@ -28,7 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.File;
 import java.util.Deque;
-import java.util.Properties;
+import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 import org.eclipse.jetty.server.NetworkConnector;
@@ -96,8 +96,8 @@ public class MavenITmng4771PluginPrefixResolutionDoesntTouchDisabledRepoTest
             System.out.println( "Bound server socket to the port " + port );
             verifier.setAutoclean( false );
             verifier.deleteDirectory( "target" );
-            Properties filterProps = verifier.newDefaultFilterProperties();
-            filterProps.setProperty( "@port@", Integer.toString( port ) );
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
+            filterProps.put( "@port@", Integer.toString( port ) );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "-U" );
             verifier.addCliArgument( "-s" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4772PluginVersionResolutionDoesntTouchDisabledRepoTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4772PluginVersionResolutionDoesntTouchDisabledRepoTest.java
@@ -30,7 +30,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Request;
@@ -97,8 +97,8 @@ public class MavenITmng4772PluginVersionResolutionDoesntTouchDisabledRepoTest
             System.out.println( "Bound server socket to the port " + port );
             verifier.setAutoclean( false );
             verifier.deleteDirectory( "target" );
-            Properties filterProps = verifier.newDefaultFilterProperties();
-            filterProps.setProperty( "@port@", Integer.toString( port ) );
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
+            filterProps.put( "@port@", Integer.toString( port ) );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "-U" );
             verifier.addCliArgument( "-s" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4785TransitiveResolutionInForkedThreadTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4785TransitiveResolutionInForkedThreadTest.java
@@ -59,7 +59,7 @@ public class MavenITmng4785TransitiveResolutionInForkedThreadTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4785" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4789ScopeInheritanceMeetsConflictTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4789ScopeInheritanceMeetsConflictTest.java
@@ -59,7 +59,7 @@ public class MavenITmng4789ScopeInheritanceMeetsConflictTest
         verifier.deleteDirectory( "target" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4791ProjectBuilderResolvesRemotePomArtifactTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4791ProjectBuilderResolvesRemotePomArtifactTest.java
@@ -59,7 +59,7 @@ public class MavenITmng4791ProjectBuilderResolvesRemotePomArtifactTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4791" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4800NearestWinsVsScopeWideningTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4800NearestWinsVsScopeWideningTest.java
@@ -71,7 +71,7 @@ public class MavenITmng4800NearestWinsVsScopeWideningTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4800" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4814ReResolutionOfDependenciesDuringReactorTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4814ReResolutionOfDependenciesDuringReactorTest.java
@@ -61,7 +61,7 @@ public class MavenITmng4814ReResolutionOfDependenciesDuringReactorTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4814" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArguments( "validate",
             "org.apache.maven.its.plugins:maven-it-plugin-dependency-resolution:2.1-SNAPSHOT:aggregate-test" );
         verifier.execute();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4829ChecksumFailureWarningTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4829ChecksumFailureWarningTest.java
@@ -58,7 +58,7 @@ public class MavenITmng4829ChecksumFailureWarningTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4829" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4834ParentProjectResolvedFromRemoteReposTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4834ParentProjectResolvedFromRemoteReposTest.java
@@ -59,7 +59,7 @@ public class MavenITmng4834ParentProjectResolvedFromRemoteReposTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4834" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4840MavenPrerequisiteTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4840MavenPrerequisiteTest.java
@@ -57,7 +57,7 @@ public class MavenITmng4840MavenPrerequisiteTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4840" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8" );
         try
         {
             verifier.addCliArgument( "validate" );
@@ -89,7 +89,7 @@ public class MavenITmng4840MavenPrerequisiteTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4840" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "org.apache.maven.its.mng4840:maven-mng4840-plugin:touch" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4842ParentResolutionOfDependencyPomTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4842ParentResolutionOfDependencyPomTest.java
@@ -60,7 +60,7 @@ public class MavenITmng4842ParentResolutionOfDependencyPomTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4842" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();
@@ -90,7 +90,7 @@ public class MavenITmng4842ParentResolutionOfDependencyPomTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4842" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4883FailUponOverconstrainedVersionRangesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4883FailUponOverconstrainedVersionRangesTest.java
@@ -57,7 +57,7 @@ public class MavenITmng4883FailUponOverconstrainedVersionRangesTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4883" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         try
         {
             verifier.addCliArgument( "validate" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4895PluginDepWithNonRelocatedMavenApiTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4895PluginDepWithNonRelocatedMavenApiTest.java
@@ -58,7 +58,7 @@ public class MavenITmng4895PluginDepWithNonRelocatedMavenApiTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4895" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4913UserPropertyVsDependencyPomPropertyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4913UserPropertyVsDependencyPomPropertyTest.java
@@ -59,7 +59,7 @@ public class MavenITmng4913UserPropertyVsDependencyPomPropertyTest
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "-Dmng4913.version=98.76" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4925ContainerLookupRealmDuringMojoExecTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4925ContainerLookupRealmDuringMojoExecTest.java
@@ -58,7 +58,7 @@ public class MavenITmng4925ContainerLookupRealmDuringMojoExecTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4925" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4952MetadataReleaseInfoUpdateTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4952MetadataReleaseInfoUpdateTest.java
@@ -23,7 +23,7 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
-import java.util.Properties;
+import java.util.Map;
 
 import org.apache.maven.shared.utils.io.FileUtils;
 import org.junit.jupiter.api.Test;
@@ -58,7 +58,7 @@ public class MavenITmng4952MetadataReleaseInfoUpdateTest
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng4952" );
 
-        Properties props = verifier.newDefaultFilterProperties();
+        Map<String, String> props = verifier.newDefaultFilterMap();
 
         props.put( "@version@", "1.0" );
         verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8", props );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4955LocalVsRemoteSnapshotResolutionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4955LocalVsRemoteSnapshotResolutionTest.java
@@ -66,7 +66,7 @@ public class MavenITmng4955LocalVsRemoteSnapshotResolutionTest
         verifier.deleteDirectory( "target" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4963ParentResolutionFromMirrorTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4963ParentResolutionFromMirrorTest.java
@@ -59,7 +59,7 @@ public class MavenITmng4963ParentResolutionFromMirrorTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4963" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4973ExtensionVisibleToPluginInReactorTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4973ExtensionVisibleToPluginInReactorTest.java
@@ -60,7 +60,7 @@ public class MavenITmng4973ExtensionVisibleToPluginInReactorTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4973" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4987TimestampBasedSnapshotSelectionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4987TimestampBasedSnapshotSelectionTest.java
@@ -59,7 +59,7 @@ public class MavenITmng4987TimestampBasedSnapshotSelectionTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng4987" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4991NonProxyHostsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4991NonProxyHostsTest.java
@@ -25,7 +25,7 @@ import org.apache.maven.shared.verifier.Verifier;
 import java.io.File;
 import java.net.InetAddress;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
@@ -94,12 +94,12 @@ public class MavenITmng4991NonProxyHostsTest
             verifier.setAutoclean( false );
             verifier.deleteDirectory( "target" );
             verifier.deleteArtifacts( "org.apache.maven.its.mng4991" );
-            Properties filterProps = verifier.newDefaultFilterProperties();
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
             int port = ( (NetworkConnector) server.getConnectors()[0] ).getLocalPort();
-            filterProps.setProperty( "@port@", Integer.toString( port ) );
+            filterProps.put( "@port@", Integer.toString( port ) );
             int proxyPort = ( (NetworkConnector) proxy.getConnectors()[0] ).getLocalPort();
-            filterProps.setProperty( "@proxyPort@", Integer.toString( proxyPort ) );
-            filterProps.setProperty( "@localhost@", InetAddress.getLoopbackAddress().getCanonicalHostName() );
+            filterProps.put( "@proxyPort@", Integer.toString( proxyPort ) );
+            filterProps.put( "@localhost@", InetAddress.getLoopbackAddress().getCanonicalHostName() );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "-s" );
             verifier.addCliArgument( "settings.xml" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5006VersionRangeDependencyParentResolutionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5006VersionRangeDependencyParentResolutionTest.java
@@ -61,7 +61,7 @@ public class MavenITmng5006VersionRangeDependencyParentResolutionTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng5006" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5019StringBasedCompLookupFromChildPluginRealmTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5019StringBasedCompLookupFromChildPluginRealmTest.java
@@ -57,7 +57,7 @@ public class MavenITmng5019StringBasedCompLookupFromChildPluginRealmTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng5019" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5064SuppressSnapshotUpdatesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5064SuppressSnapshotUpdatesTest.java
@@ -29,7 +29,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Request;
@@ -107,8 +107,8 @@ public class MavenITmng5064SuppressSnapshotUpdatesTest
             verifier.setAutoclean( false );
             verifier.deleteDirectory( "target" );
             verifier.deleteArtifacts( "org.apache.maven.its.mng5064" );
-            Properties filterProps = verifier.newDefaultFilterProperties();
-            filterProps.setProperty( "@port@", Integer.toString( port ) );
+            Map<String, String> filterProps = verifier.newDefaultFilterMap();
+            filterProps.put( "@port@", Integer.toString( port ) );
             verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
             verifier.addCliArgument( "-nsu" );
             verifier.addCliArgument( "-s" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5096ExclusionAtDependencyWithImpliedClassifierTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5096ExclusionAtDependencyWithImpliedClassifierTest.java
@@ -60,7 +60,7 @@ public class MavenITmng5096ExclusionAtDependencyWithImpliedClassifierTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng5096" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5135AggregatorDepResolutionModuleExtensionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5135AggregatorDepResolutionModuleExtensionTest.java
@@ -58,7 +58,7 @@ public class MavenITmng5135AggregatorDepResolutionModuleExtensionTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng5135" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "org.apache.maven.its.plugins:maven-it-plugin-dependency-resolution:aggregate-test" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5175WagonHttpTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5175WagonHttpTest.java
@@ -28,7 +28,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Properties;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
@@ -122,8 +123,8 @@ public class MavenITmng5175WagonHttpTest
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
 
-        Properties filterProps = new Properties();
-        filterProps.setProperty( "@port@", Integer.toString( port ) );
+        Map<String, String> filterProps = new HashMap<>();
+        filterProps.put( "@port@", Integer.toString( port ) );
 
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
 

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5280SettingsProfilesRepositoriesOrderTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5280SettingsProfilesRepositoriesOrderTest.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
-import java.util.Properties;
+import java.util.Map;
 
 import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Request;
@@ -101,8 +101,8 @@ public class MavenITmng5280SettingsProfilesRepositoriesOrderTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng5280" );
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        filterProps.setProperty( "@httpserver.port@", Integer.toString( httpPort ) );
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
+        filterProps.put( "@httpserver.port@", Integer.toString( httpPort ) );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
@@ -138,8 +138,8 @@ public class MavenITmng5280SettingsProfilesRepositoriesOrderTest
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
         verifier.deleteArtifacts( "org.apache.maven.its.mng5280" );
-        Properties filterProps = verifier.newDefaultFilterProperties();
-        filterProps.setProperty( "@httpserver.port@", Integer.toString( httpPort ) );
+        Map<String, String> filterProps = verifier.newDefaultFilterMap();
+        filterProps.put( "@httpserver.port@", Integer.toString( httpPort ) );
         verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", filterProps );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5639ImportScopePomResolutionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5639ImportScopePomResolutionTest.java
@@ -48,7 +48,7 @@ public class MavenITmng5639ImportScopePomResolutionTest
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.deleteArtifacts( "org.apache.maven.its.mng5639" );
 
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
 

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5663NestedImportScopePomResolutionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5663NestedImportScopePomResolutionTest.java
@@ -53,8 +53,8 @@ public class MavenITmng5663NestedImportScopePomResolutionTest
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.deleteArtifacts( "org.apache.maven.its.mng5663" );
 
-        verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8", verifier.newDefaultFilterProperties() );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8" );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "--settings" );
         verifier.addCliArgument( "settings.xml" );
 

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5716ToolchainsTypeTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5716ToolchainsTypeTest.java
@@ -23,6 +23,7 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
+import java.util.Map;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
@@ -57,8 +58,8 @@ public class MavenITmng5716ToolchainsTypeTest
         new File( javaHome, "bin/javac.exe").createNewFile();
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
-        Properties properties = verifier.newDefaultFilterProperties();
-        properties.setProperty( "@javaHome@", javaHome.getAbsolutePath() );
+        Map<String, String> properties = verifier.newDefaultFilterMap();
+        properties.put( "@javaHome@", javaHome.getAbsolutePath() );
 
         verifier.filterFile( "toolchains.xml", "toolchains.xml", "UTF-8", properties );
 

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5771CoreExtensionsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5771CoreExtensionsTest.java
@@ -4,7 +4,7 @@ import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
-import java.util.Properties;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +28,7 @@ public class MavenITmng5771CoreExtensionsTest
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-5771-core-extensions" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
 
         verifier = newVerifier( new File( testDir, "client" ).getAbsolutePath() );
         verifier.deleteDirectory( "target" );
@@ -47,7 +47,7 @@ public class MavenITmng5771CoreExtensionsTest
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-5771-core-extensions" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
 
         verifier = newVerifier( new File( testDir, "client-no-descriptor" ).getAbsolutePath() );
         verifier.deleteDirectory( "target" );
@@ -79,8 +79,8 @@ public class MavenITmng5771CoreExtensionsTest
         server.start();
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
-        Properties properties = verifier.newDefaultFilterProperties();
-        properties.setProperty("@port@", Integer.toString( server.port() ) );
+        Map<String, String> properties = verifier.newDefaultFilterMap();
+        properties.put("@port@", Integer.toString( server.port() ) );
         String mirrorOf;
         if ( matchesVersionRange( "[4.0.0-alpha-1,)" ) )
         {
@@ -90,7 +90,7 @@ public class MavenITmng5771CoreExtensionsTest
         {
             mirrorOf = "external:*";
         }
-        properties.setProperty("@mirrorOf@", mirrorOf );
+        properties.put("@mirrorOf@", mirrorOf );
         verifier.filterFile( "settings-template-mirror-auth.xml", "settings.xml", "UTF-8", properties );
 
         verifier = newVerifier( new File( testDir, "client" ).getAbsolutePath() );
@@ -117,7 +117,7 @@ public class MavenITmng5771CoreExtensionsTest
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-5771-core-extensions" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
 
         verifier = newVerifier( new File( testDir, "client-properties" ).getAbsolutePath() );
         verifier.deleteDirectory( "target" );
@@ -142,7 +142,7 @@ public class MavenITmng5771CoreExtensionsTest
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-5771-core-extensions" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
 
         verifier = newVerifier( new File( testDir, "client-config" ).getAbsolutePath() );
         verifier.deleteDirectory( "target" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5774ConfigurationProcessorsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5774ConfigurationProcessorsTest.java
@@ -24,7 +24,7 @@ public class MavenITmng5774ConfigurationProcessorsTest
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-5774-configuration-processors" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
 
         verifier = newVerifier( new File( testDir, "build-with-one-processor-valid" ).getAbsolutePath() );
         verifier.deleteDirectory( "target" );
@@ -49,7 +49,7 @@ public class MavenITmng5774ConfigurationProcessorsTest
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-5774-configuration-processors" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
 
         verifier = newVerifier( new File( testDir, "build-with-two-processors-invalid" ).getAbsolutePath() );
         verifier.deleteDirectory( "target" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6210CoreExtensionsCustomScopesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6210CoreExtensionsCustomScopesTest.java
@@ -47,7 +47,7 @@ public class MavenITmng6210CoreExtensionsCustomScopesTest
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-6210-core-extensions-scopes" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
-        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" );
 
         verifier = newVerifier( new File( testDir, "client" ).getAbsolutePath() );
         verifier.deleteDirectory( "target" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6772NestedImportScopeRepositoryOverride.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6772NestedImportScopeRepositoryOverride.java
@@ -58,7 +58,7 @@ public class MavenITmng6772NestedImportScopeRepositoryOverride
         overrideGlobalSettings( testDir, verifier );
         verifier.deleteArtifacts( "org.apache.maven.its.mng6772" );
 
-        verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8" );
 
         verifier.addCliArgument( "validate" );
         verifier.execute();
@@ -76,7 +76,7 @@ public class MavenITmng6772NestedImportScopeRepositoryOverride
         overrideGlobalSettings( testDir, verifier );
         verifier.deleteArtifacts( "org.apache.maven.its.mng6772" );
 
-        verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "pom-template.xml", "pom.xml", "UTF-8" );
 
         verifier.addCliArgument( "compile" );
         verifier.execute();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7529VersionRangeRepositorySelection.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7529VersionRangeRepositorySelection.java
@@ -53,7 +53,7 @@ public class MavenITmng7529VersionRangeRepositorySelection
     verifier.addCliArgument("--settings");
     verifier.addCliArgument("settings.xml");
 
-    verifier.filterFile("settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties());
+    verifier.filterFile("settings-template.xml", "settings.xml", "UTF-8");
     verifier.addCliArgument("validate");
     verifier.execute();
     verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7566JavaPrerequisiteTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7566JavaPrerequisiteTest.java
@@ -37,7 +37,7 @@ class MavenITmng7566JavaPrerequisiteTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng7566" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8" );
         try
         {
             verifier.addCliArgument( "validate" );
@@ -69,7 +69,7 @@ class MavenITmng7566JavaPrerequisiteTest
         verifier.deleteArtifacts( "org.apache.maven.its.mng7566" );
         verifier.addCliArgument( "-s" );
         verifier.addCliArgument( "settings.xml" );
-        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
+        verifier.filterFile( "../settings-template.xml", "settings.xml", "UTF-8" );
         verifier.addCliArgument( "org.apache.maven.its.mng7566:maven-mng7566-plugin:touch" );
         verifier.execute();
         verifier.verifyErrorFreeLog();


### PR DESCRIPTION
This should be the last _big_ PR. 

These three calls are basically identical (at least with the current version of the Verifier):
```java
(1) verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterProperties() );
(2) verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8", verifier.newDefaultFilterMap() );
(3) verifier.filterFile( "settings-template.xml", "settings.xml", "UTF-8" ); // uses the default filter map under the hood
```
so I figured I would go with option (3) since that's the least verbose.