### PR TITLE
[MNG-7661] Replace deprecated 'verifier.setMavenDebug()'

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0828PluginConfigValuesInDebugTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng0828PluginConfigValuesInDebugTest.java
@@ -60,7 +60,7 @@ public class MavenITmng0828PluginConfigValuesInDebugTest
         Verifier verifier = newVerifier( testDir.getAbsolutePath() );
         verifier.setAutoclean( false );
         verifier.deleteDirectory( "target" );
-        verifier.setMavenDebug( true );
+        verifier.addCliArgument( "-X" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5175WagonHttpTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5175WagonHttpTest.java
@@ -133,7 +133,7 @@ public class MavenITmng5175WagonHttpTest
         verifier.addCliArgument( "settings.xml" );
         verifier.addCliArgument( "--fail-never" );
         verifier.addCliArgument( "--errors" );
-        verifier.setMavenDebug( true );
+        verifier.addCliArgument( "-X" );
         verifier.addCliArgument( "validate" );
         verifier.execute();
 

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5214DontMapWsdlToJar.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5214DontMapWsdlToJar.java
@@ -49,7 +49,7 @@ public class MavenITmng5214DontMapWsdlToJar
 
         Verifier setupVerifier = newVerifier( setupDir.getAbsolutePath() );
         setupVerifier.setAutoclean( false );
-        setupVerifier.setMavenDebug( true );
+        setupVerifier.addCliArgument( "-X" );
         setupVerifier.deleteDirectory( "target" );
         setupVerifier.deleteArtifacts( "org.apache.maven.its.mng5214" );
         setupVerifier.setLogFileName( "log-setup.txt" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5230MakeReactorWithExcludesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5230MakeReactorWithExcludesTest.java
@@ -61,7 +61,7 @@ public class MavenITmng5230MakeReactorWithExcludesTest
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-5230-make-reactor-with-excludes" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath(), true );
-        verifier.setMavenDebug( true );
+        verifier.addCliArgument( "-X" );
         verifier.setAutoclean( false );
         clean( verifier );
         verifier.addCliArgument( "-pl" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5581LifecycleMappingDelegate.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5581LifecycleMappingDelegate.java
@@ -72,7 +72,7 @@ public class MavenITmng5581LifecycleMappingDelegate
         verifier = newVerifier( projectDir.getAbsolutePath() );
         verifier.setLogFileName( "test-only-log.txt" );
         verifier.setForkJvm( true );
-        verifier.setMavenDebug( true );
+        verifier.addCliArgument( "-X" );
         verifier.addCliArgument( "test-only" );
         verifier.execute();
         verifier.verifyErrorFreeLog();

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5895CIFriendlyUsageWithPropertyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5895CIFriendlyUsageWithPropertyTest.java
@@ -60,7 +60,6 @@ public class MavenITmng5895CIFriendlyUsageWithPropertyTest
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-5895-ci-friendly-usage-with-property" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath(), false );
-        verifier.setMavenDebug( false );
         verifier.setAutoclean( false );
 
         //verifier.setLogFileName( "log-only.txt" );
@@ -81,7 +80,6 @@ public class MavenITmng5895CIFriendlyUsageWithPropertyTest
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-5895-ci-friendly-usage-with-property" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath(), false );
-        verifier.setMavenDebug( false );
         verifier.setAutoclean( false );
 
         verifier.setLogFileName( "log-bc.txt" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5965ParallelBuildMultipliesWorkTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5965ParallelBuildMultipliesWorkTest.java
@@ -32,7 +32,6 @@ public class MavenITmng5965ParallelBuildMultipliesWorkTest
             ResourceExtractor.simpleExtractResources( getClass(), "/mng-5965-parallel-build-multiplies-work" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath(), false );
-        verifier.setMavenDebug( false );
         verifier.setAutoclean( false );
 
         verifier.setLogFileName( "log-only.txt" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6057CheckReactorOrderTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6057CheckReactorOrderTest.java
@@ -58,7 +58,6 @@ public class MavenITmng6057CheckReactorOrderTest
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-6057-check-reactor-order" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath(), false );
-        verifier.setMavenDebug( false );
         verifier.setAutoclean( false );
 
         verifier.setLogFileName( "log-only.txt" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6090CIFriendlyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6090CIFriendlyTest.java
@@ -61,7 +61,6 @@ public class MavenITmng6090CIFriendlyTest
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-6090-ci-friendly" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath(), false );
-        verifier.setMavenDebug( false );
         verifier.setAutoclean( false );
 
         verifier.addCliArgument( "-Drevision=1.2" );
@@ -72,7 +71,6 @@ public class MavenITmng6090CIFriendlyTest
         verifier.verifyErrorFreeLog();
 
         verifier = newVerifier( testDir.getAbsolutePath(), false );
-        verifier.setMavenDebug( false );
         verifier.setAutoclean( false );
 
         verifier.addCliArgument( "-Drevision=1.2" );
@@ -90,7 +88,6 @@ public class MavenITmng6090CIFriendlyTest
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-6090-ci-friendly" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath(), false );
-        verifier.setMavenDebug( false );
         verifier.setAutoclean( false );
         verifier.setForkJvm(true);
 
@@ -102,7 +99,6 @@ public class MavenITmng6090CIFriendlyTest
         verifier.verifyErrorFreeLog();
 
         verifier = newVerifier( testDir.getAbsolutePath(), false );
-        verifier.setMavenDebug( false );
         verifier.setAutoclean( false );
         verifier.setForkJvm(true);
 

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6391PrintVersionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6391PrintVersionTest.java
@@ -62,7 +62,6 @@ public class MavenITmng6391PrintVersionTest
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-6391-print-version" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath(), false );
-        verifier.setMavenDebug( false );
         verifier.setAutoclean( false );
 
         verifier.setLogFileName( "version-log.txt" );
@@ -107,7 +106,6 @@ public class MavenITmng6391PrintVersionTest
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-6391-print-version-aggregator" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath(), false );
-        verifier.setMavenDebug( false );
         verifier.setAutoclean( false );
 
         verifier.setLogFileName( "version-log.txt" );

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6656BuildConsumer.java
@@ -73,7 +73,6 @@ public class MavenITmng6656BuildConsumer
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-6656-buildconsumer" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath(), false );
-        verifier.setMavenDebug( false );
         verifier.setAutoclean( false );
         verifier.addCliArgument( "-Dchangelist=MNG6656" );
 

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6957BuildConsumer.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng6957BuildConsumer.java
@@ -73,7 +73,6 @@ public class MavenITmng6957BuildConsumer
         File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-6957-buildconsumer" );
 
         Verifier verifier = newVerifier( testDir.getAbsolutePath(), false );
-        verifier.setMavenDebug( false );
         verifier.setAutoclean( false );
         verifier.addCliArgument( "-Dchangelist=MNG6957" );
 


### PR DESCRIPTION
@slawekjaranowski @michael-o hey again, this is the last one of these verifier PRs, and actually pretty small and trivial to review (and I already had it ready for some time).

 * `verifier.setMavenDebug( false );` is the default, so there is actually no need to have it (not mentioning, there is no direct replacement for this in the new API -- the replacement is to _not_  add the `-X` argument).