### PR TITLE
[MNG-7667] Fix DownloadMojo to properly resolve

### DIFF
--- a/core-it-support/maven-it-plugin-bootstrap/src/main/java/org/apache/maven/its/bootstrap/DownloadMojo.java
+++ b/core-it-support/maven-it-plugin-bootstrap/src/main/java/org/apache/maven/its/bootstrap/DownloadMojo.java
@@ -124,9 +124,7 @@ public class DownloadMojo
             {
                 org.eclipse.aether.graph.Dependency root = RepositoryUtils.toDependency(
                         dependency, repositorySystemSession.getArtifactTypeRegistry() );
-
-                CollectRequest collectRequest =
-                        new CollectRequest( root, null, repos );
+                CollectRequest collectRequest = new CollectRequest( root, null, repos );
                 collectRequest.setRequestContext( "bootstrap" );
                 DependencyRequest request = new DependencyRequest( collectRequest, null ) ;
                 System.out.println( "Resolving: " + root.getArtifact() );

--- a/core-it-support/maven-it-plugin-bootstrap/src/main/java/org/apache/maven/its/bootstrap/DownloadMojo.java
+++ b/core-it-support/maven-it-plugin-bootstrap/src/main/java/org/apache/maven/its/bootstrap/DownloadMojo.java
@@ -42,8 +42,6 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.collection.CollectRequest;
 import org.eclipse.aether.repository.RemoteRepository;
-import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
-import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.eclipse.aether.resolution.DependencyRequest;
 
 /**
@@ -127,13 +125,8 @@ public class DownloadMojo
                 org.eclipse.aether.graph.Dependency root = RepositoryUtils.toDependency(
                         dependency, repositorySystemSession.getArtifactTypeRegistry() );
 
-                ArtifactDescriptorRequest artifactDescriptorRequest =
-                        new ArtifactDescriptorRequest( root.getArtifact(), repos, "bootstrap" );
-                ArtifactDescriptorResult artifactDescriptorResult =
-                        repositorySystem.readArtifactDescriptor( repositorySystemSession, artifactDescriptorRequest );
-
                 CollectRequest collectRequest =
-                        new CollectRequest( root, artifactDescriptorResult.getDependencies(), repos );
+                        new CollectRequest( root, null, repos );
                 collectRequest.setRequestContext( "bootstrap" );
                 DependencyRequest request = new DependencyRequest( collectRequest, null ) ;
                 System.out.println( "Resolving: " + root.getArtifact() );

--- a/core-it-support/maven-it-plugin-bootstrap/src/main/java/org/apache/maven/its/bootstrap/DownloadMojo.java
+++ b/core-it-support/maven-it-plugin-bootstrap/src/main/java/org/apache/maven/its/bootstrap/DownloadMojo.java
@@ -40,12 +40,17 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingRequest;
+import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.ArtifactTypeRegistry;
 import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.collection.DependencySelector;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.util.graph.selector.AndDependencySelector;
+import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
+import org.eclipse.aether.util.graph.selector.ScopeDependencySelector;
 
 /**
  * Boostrap plugin to download all required dependencies (provided in file) or to collect lifecycle bound build plugin
@@ -124,6 +129,27 @@ public class DownloadMojo
         RepositorySystemSession repositorySystemSession = projectBuildingRequest.getRepositorySession();
         List<RemoteRepository> repos = RepositoryUtils.toRepos( projectBuildingRequest.getRemoteRepositories() );
         ArtifactTypeRegistry registry = RepositoryUtils.newArtifactTypeRegistry( artifactHandlerManager );
+
+        // Hack ahead: maven-plugin-plugin depends on maven-plugin-tools-ant and maven-plugin-tools-beanshell as
+        // runtime/optional, so this way of "dependency resolution" as below WILL NOT resolve those two as
+        // OptionalDependencySelector will kick in and kick them out, BUT those two are resolved when m-p-p is used
+        // as plugin. To properly solve this we should "push" all one level up: set root we resolve and enumerate all
+        // dependencies we want to resolve, but alas that would slow down the thing as we'd need to build POMs for all
+        // resolved projects. OTOH, we cannot globally omit OptionalDependencySelector either, as that would lead us
+        // to some ancient obscure unresolvable artifacts and would abort Bootstrap process.
+        //
+        // In short, when we are resolving maven-plugin-plugin, we use custom session for it with modified selectors,
+        // while for everything else everything remains same as before.
+
+        RepositorySystemSession resolveSession;
+
+        DefaultRepositorySystemSession hackSession = new DefaultRepositorySystemSession( repositorySystemSession );
+        DependencySelector depFilter = new AndDependencySelector(
+                new ScopeDependencySelector( "test", "provided" ),
+                // new OptionalDependencySelector(), <-- we need this!
+                new ExclusionDependencySelector() );
+        hackSession.setDependencySelector( depFilter );
+
         for ( Dependency dependency : dependencies )
         {
             try
@@ -133,7 +159,15 @@ public class DownloadMojo
                         new CollectRequest( Collections.singletonList( dep ), Collections.emptyList(), repos ),
                         null );
                 System.out.println( "Resolving: " + dep.getArtifact() );
-                repositorySystem.resolveDependencies( repositorySystemSession, request );
+                if ( "maven-plugin-plugin".equals( dependency.getArtifactId() ) )
+                {
+                    resolveSession = hackSession;
+                }
+                else
+                {
+                    resolveSession = repositorySystemSession;
+                }
+                repositorySystem.resolveDependencies( resolveSession, request );
             }
             catch ( Exception e )
             {


### PR DESCRIPTION
The m-p-p depends on m-p-tools-ant and m-p-tools-beanshell as runtime/optional, and the way DownloadMojo resolves every artifact causes that OptionalDependencySelector filter these out even at "collection" stage (as depth >= 2).

Hence, fix DownloadMojo to resolve properly, that actually shifts all the tree "one level up", and hence result is same as in Maven, as the optional dependencies become "first level sibling".

---

https://issues.apache.org/jira/browse/MNG-7667