### PR TITLE
[MNG-7706] Fix for ITs

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4305LocalRepoBasedirTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4305LocalRepoBasedirTest.java
@@ -64,7 +64,7 @@ public class MavenITmng4305LocalRepoBasedirTest
 
         // NOTE: This deliberately compares the paths on the String level, not via File.equals()
         assertEquals( new File( verifier.getLocalRepository() ).getAbsolutePath(),
-                      props.getProperty( "localRepository.basedir" ) );
+                      props.getProperty( "localRepositoryBasedir" ) );
     }
 
 }

--- a/core-it-suite/src/test/resources/mng-4305/pom.xml
+++ b/core-it-suite/src/test/resources/mng-4305/pom.xml
@@ -41,7 +41,7 @@ under the License.
         <configuration>
           <outputFile>target/basedir.properties</outputFile>
           <expressions>
-            <expression>localRepository/basedir</expression>
+            <expression>localRepositoryBasedir</expression>
           </expressions>
         </configuration>
         <executions>

--- a/core-it-support/core-it-plugins/maven-it-plugin-expression/src/main/java/org/apache/maven/plugin/coreit/EvalMojo.java
+++ b/core-it-support/core-it-plugins/maven-it-plugin-expression/src/main/java/org/apache/maven/plugin/coreit/EvalMojo.java
@@ -117,8 +117,8 @@ public class EvalMojo
     /**
      * The local repository of the current build against which expressions are evaluated.
      */
-    @Parameter( defaultValue = "${localRepository}", readonly = true )
-    private Object localRepository;
+    @Parameter( defaultValue = "${session.request.localRepositoryPath}", readonly = true )
+    private Object localRepositoryBasedir;
 
     /**
      * Runs this mojo.
@@ -158,7 +158,7 @@ public class EvalMojo
             contexts.put( "pom", project );
             contexts.put( "settings", settings );
             contexts.put( "session", session );
-            contexts.put( "localRepository", localRepository );
+            contexts.put( "localRepositoryBasedir", localRepositoryBasedir );
 
             for ( String expression : expressions )
             {


### PR DESCRIPTION
The MNG-7706 deprecates ancient ArtifactRepository type use to get access to local repository, and issues warning as for any other deprecated Mojo parameters.

But alas, in ITs the MNG-5576 completely unrelated IT there is an assertion to have WARNING-free log. This IT uses the IT-plugins/IT-plugin-expression EvalMojo, that in turn uses the deprecated `${localRepository}` parameter (but does not use it). Result is, Maven 3.9.1 emits a WARNING about use of deprecated parameter and the IT fails.

Further inspection shows, that while EvalMojo injects ArtifactRepository for local repository, there is only one IT that actually uses it, the MNG-4305, but even that one is interested in basedir of the local repository only. So to say, the use of deprecated ArtifactRepository type is not needed at all.

Fix:
* change EvalMojo to not expose in context the localRepository (w/ type ArtifactRepository), but a new expression `localRepositoryBasedir` only, that is injected in non-deprecated way (in real life repoSysSession would be injected, but in IT we keep all super-safe and use Object types).
* adjusted MNG-4305 to use new epxression instead to use object reflection in template to get basedir from ArtifactRepository
* This makes the originally failing MNG-5576 pass, as warning due EvalMojo is gone.

See
https://issues.apache.org/jira/browse/MNG-7706
https://github.com/apache/maven/pull/1009