### PR TITLE
Detecting tests which was not added to TestSuiteOrdering

### DIFF
--- a/core-it-suite/pom.xml
+++ b/core-it-suite/pom.xml
@@ -498,6 +498,8 @@ under the License.
           <includes>
             <include>**/MavenIT*.java</include>
           </includes>
+          <!-- test annotated by @Tag("disabled") will be skipped from executions -->
+          <excludedGroups>disabled</excludedGroups>
           <forkCount>0</forkCount>
           <reuseForks>true</reuseForks>
           <skip>true</skip>

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4356NoNeedlessRelookupFromActiveCollectionTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4356NoNeedlessRelookupFromActiveCollectionTest.java
@@ -25,7 +25,7 @@ import org.apache.maven.shared.verifier.Verifier;
 import java.io.File;
 import java.util.Properties;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Benjamin Bentmann
  */
-@Disabled
+@Tag("disabled")
 public class MavenITmng4356NoNeedlessRelookupFromActiveCollectionTest
     extends AbstractMavenIntegrationTestCase
 {

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4565MultiConditionProfileActivationTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4565MultiConditionProfileActivationTest.java
@@ -24,7 +24,7 @@ import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
  * When multiple activators are present in a profile they should be AND'd. All activator must
  * conditions must be satisfied in order for the profile to be activated.
  */
-@Disabled
+@Tag("disabled")
 public class MavenITmng4565MultiConditionProfileActivationTest
     extends AbstractMavenIntegrationTestCase
 {

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4761PluginLevelDependencyScopesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4761PluginLevelDependencyScopesTest.java
@@ -24,7 +24,7 @@ import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author jdcasey
  */
-@Disabled
+@Tag("disabled")
 public class MavenITmng4761PluginLevelDependencyScopesTest
     extends AbstractMavenIntegrationTestCase
 {

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5206PlexusLifecycleHonoured.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5206PlexusLifecycleHonoured.java
@@ -24,7 +24,7 @@ import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Olivier Lamy
  */
-@Disabled
+@Tag("disabled")
 public class MavenITmng5206PlexusLifecycleHonoured
     extends AbstractMavenIntegrationTestCase
 {

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5418FileProjectPropertiesActivatorTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5418FileProjectPropertiesActivatorTest.java
@@ -24,7 +24,7 @@ import org.apache.maven.shared.verifier.Verifier;
 
 import java.io.File;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Olivier Lamy
  */
-@Disabled
+@Tag("disabled")
 public class MavenITmng5418FileProjectPropertiesActivatorTest
     extends AbstractMavenIntegrationTestCase
 {

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5503ZipInReactorTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5503ZipInReactorTest.java
@@ -25,6 +25,7 @@ import org.apache.maven.shared.verifier.Verifier;
 import java.io.File;
 
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author jvz
  */
+@Tag( "disabled" )
 @Disabled
 public class MavenITmng5503ZipInReactorTest
     extends AbstractMavenIntegrationTestCase

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5557ProperlyRestrictedReactor.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5557ProperlyRestrictedReactor.java
@@ -25,7 +25,7 @@ import org.apache.maven.shared.verifier.VerificationException;
 
 import java.io.File;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author jvanzyl
  */
-@Disabled
+@Tag("disabled")
 public class MavenITmng5557ProperlyRestrictedReactor
     extends AbstractMavenIntegrationTestCase
 {


### PR DESCRIPTION
Even test is skipped by `@Disabled` annotation
newer surefire schedule it for execution.

When tests are missing in TestSuiteOrdering
are executed as one of first tests in unpredictable order.

We have many options:
 - left as is
 - show info as in PR
 - break a build