### PR TITLE
[MNG-5181] Improve "missing dependency" message

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7128BlockExternalHttpReactorTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7128BlockExternalHttpReactorTest.java
@@ -60,12 +60,9 @@ public class MavenITmng7128BlockExternalHttpReactorTest
         catch ( VerificationException ve )
         {
             // Inspect the reason why the build broke.
-            verifier.verifyTextInLog( "[ERROR] Failed to execute goal on project http-repository-in-pom: "
-                + "Could not resolve dependencies for project org.apache.maven.its.mng7128:http-repository-in-pom:jar:1.0: "
-                + "Failed to collect dependencies at junit:junit:jar:1.3: "
-                + "Failed to read artifact descriptor for junit:junit:jar:1.3: "
-                + "Could not transfer artifact junit:junit:pom:1.3 from/to maven-default-http-blocker (http://0.0.0.0/): " // mirror introduced in MNG-7118
-                + "Blocked mirror for repositories: [insecure-http-repo (http://repo.maven.apache.org/, default, releases+snapshots)]" );
+            verifier.verifyTextInLog( "[ERROR] Failed to execute goal on project http-repository-in-pom: " ); // project failed
+            verifier.verifyTextInLog( "Could not transfer artifact junit:junit:pom:1.3 from/to maven-default-http-blocker (http://0.0.0.0/): " ); // mirror introduced in MNG-7118
+            verifier.verifyTextInLog( "Blocked mirror for repositories: [insecure-http-repo (http://repo.maven.apache.org/, default, releases+snapshots)]" ); // blocked mirror text present
         }
     }
 }


### PR DESCRIPTION
Related IT change, as the change for this issue made MNG-7128 IT to fail, as it was too eagerly matching whole error message string that has now due MNG-5181 changed.

To fix it, match only the key parts of the expected error message, that project failed, due transfer failure, as insecure mirror was blocked. This makes IT assert same thing, but is more flexible regarding error text change in MNG-5181.

---

Context: the modified IT fails in this PR https://github.com/apache/maven/pull/1025 as Resolver 1.9.6 carries extra information about artifact availability in the message, that makes the IT full string match fail now.

---

https://issues.apache.org/jira/browse/MNG-5185