### PR TITLE
[MNG-7754] Improve plugin validation

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5222MojoDeprecatedTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5222MojoDeprecatedTest.java
@@ -111,11 +111,12 @@ public class MavenITmng5222MojoDeprecatedTest
         verifier.verifyErrorFreeLog();
 
         List<String> logLines = verifier.loadFile( verifier.getBasedir(), verifier.getLogFileName(), false );
+        List<String> warnLines = findDeprecationWarning( logLines );
 
-        assertTrue( logLines.stream().anyMatch(s -> s.contains("Goal 'deprecated-config' is deprecated: This goal is deprecated")) );
-        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedParam2' (user property 'config.deprecatedParam2') is deprecated: No reason given")) );
-        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedArray' (user property 'config.deprecatedArray') is deprecated: deprecated array")) );
-        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedList' (user property 'config.deprecatedList') is deprecated: deprecated list")) );
+        assertTrue( warnLines.stream().anyMatch(s -> s.contains("Goal 'deprecated-config' is deprecated: This goal is deprecated")) );
+        assertTrue( warnLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedParam2' (user property 'config.deprecatedParam2') is deprecated: No reason given")) );
+        assertTrue( warnLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedArray' (user property 'config.deprecatedArray') is deprecated: deprecated array")) );
+        assertTrue( warnLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedList' (user property 'config.deprecatedList') is deprecated: deprecated list")) );
 
         Properties configProps = verifier.loadProperties( "target/config.properties" );
 
@@ -169,18 +170,19 @@ public class MavenITmng5222MojoDeprecatedTest
         verifier.verifyErrorFreeLog();
 
         List<String> logLines = verifier.loadFile( verifier.getBasedir(), verifier.getLogFileName(), false );
+        List<String> warnLines = findDeprecationWarning( logLines );
 
-        assertTrue( logLines.stream().anyMatch(s -> s.contains("Goal 'deprecated-config' is deprecated: This goal is deprecated")) );
-        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedParam' is deprecated: I'm deprecated param")) );
-        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedParam2' (user property 'config.deprecatedParam2') is deprecated: No reason given")) );
-        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedParamWithDefaultConstant' is deprecated: deprecated with constant value")) );
-        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedParamWithDefaultEvaluate' is deprecated: deprecated with evaluate value")) );
-        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedArray' (user property 'config.deprecatedArray') is deprecated: deprecated array")) );
-        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedArrayWithDefaults' is deprecated: deprecated array")) );
-        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedList' (user property 'config.deprecatedList') is deprecated: deprecated list")) );
-        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedListWithDefaults' is deprecated: deprecated list")) );
-        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedProperties' is deprecated: deprecated properties")) );
-        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedMap' is deprecated: deprecated map")) );
+        assertTrue( warnLines.stream().anyMatch(s -> s.contains("Goal 'deprecated-config' is deprecated: This goal is deprecated")) );
+        assertTrue( warnLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedParam' is deprecated: I'm deprecated param")) );
+        assertTrue( warnLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedParam2' (user property 'config.deprecatedParam2') is deprecated: No reason given")) );
+        assertTrue( warnLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedParamWithDefaultConstant' is deprecated: deprecated with constant value")) );
+        assertTrue( warnLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedParamWithDefaultEvaluate' is deprecated: deprecated with evaluate value")) );
+        assertTrue( warnLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedArray' (user property 'config.deprecatedArray') is deprecated: deprecated array")) );
+        assertTrue( warnLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedArrayWithDefaults' is deprecated: deprecated array")) );
+        assertTrue( warnLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedList' (user property 'config.deprecatedList') is deprecated: deprecated list")) );
+        assertTrue( warnLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedListWithDefaults' is deprecated: deprecated list")) );
+        assertTrue( warnLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedProperties' is deprecated: deprecated properties")) );
+        assertTrue( warnLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedMap' is deprecated: deprecated map")) );
 
         Properties configProps = verifier.loadProperties( "target/config.properties" );
 
@@ -214,5 +216,19 @@ public class MavenITmng5222MojoDeprecatedTest
         assertEquals( "value2", configProps.remove( "deprecatedMap.key2" ) );
 
         assertTrue( "not checked config properties: " + configProps, configProps.isEmpty() );
+    }
+
+    private List<String> findDeprecationWarning( List<String> logLines )
+    {
+        Pattern pattern = Pattern.compile( ".* (Parameter|Goal) .* is deprecated:.*" );
+        List<String> result = new ArrayList<>();
+        for ( String line : logLines )
+        {
+            if ( pattern.matcher( line ).matches() )
+            {
+                result.add( line );
+            }
+        }
+        return result;
     }
 }

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5222MojoDeprecatedTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5222MojoDeprecatedTest.java
@@ -63,12 +63,8 @@ public class MavenITmng5222MojoDeprecatedTest
         verifier.verifyErrorFreeLog();
 
         List<String> logLines = verifier.loadFile( verifier.getBasedir(), verifier.getLogFileName(), false );
-        List<String> warnLines = findDeprecationWarning( logLines );
 
-        assertTrue( warnLines.remove(
-            "[WARNING] Goal 'deprecated-config' is deprecated: This goal is deprecated" ) );
-
-        assertTrue( "Not verified line: " + warnLines, warnLines.isEmpty() );
+        assertTrue( logLines.stream().anyMatch(s -> s.contains("Goal 'deprecated-config' is deprecated: This goal is deprecated")) );
 
         Properties configProps = verifier.loadProperties( "target/config.properties" );
 
@@ -115,21 +111,11 @@ public class MavenITmng5222MojoDeprecatedTest
         verifier.verifyErrorFreeLog();
 
         List<String> logLines = verifier.loadFile( verifier.getBasedir(), verifier.getLogFileName(), false );
-        List<String> warnLines = findDeprecationWarning( logLines );
 
-        assertTrue( warnLines.remove(
-            "[WARNING] Goal 'deprecated-config' is deprecated: This goal is deprecated" ) );
-
-        assertTrue( warnLines.remove(
-            "[WARNING] Parameter 'deprecatedParam2' (user property 'config.deprecatedParam2') is deprecated: No reason given" ) );
-
-        assertTrue( warnLines.remove(
-            "[WARNING] Parameter 'deprecatedArray' (user property 'config.deprecatedArray') is deprecated: deprecated array" ) );
-
-        assertTrue( warnLines.remove(
-            "[WARNING] Parameter 'deprecatedList' (user property 'config.deprecatedList') is deprecated: deprecated list" ) );
-
-        assertTrue( "Not verified line: " + warnLines, warnLines.isEmpty() );
+        assertTrue( logLines.stream().anyMatch(s -> s.contains("Goal 'deprecated-config' is deprecated: This goal is deprecated")) );
+        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedParam2' (user property 'config.deprecatedParam2') is deprecated: No reason given")) );
+        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedArray' (user property 'config.deprecatedArray') is deprecated: deprecated array")) );
+        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedList' (user property 'config.deprecatedList') is deprecated: deprecated list")) );
 
         Properties configProps = verifier.loadProperties( "target/config.properties" );
 
@@ -183,42 +169,18 @@ public class MavenITmng5222MojoDeprecatedTest
         verifier.verifyErrorFreeLog();
 
         List<String> logLines = verifier.loadFile( verifier.getBasedir(), verifier.getLogFileName(), false );
-        List<String> warnLines = findDeprecationWarning( logLines );
 
-        assertTrue( warnLines.remove(
-            "[WARNING] Goal 'deprecated-config' is deprecated: This goal is deprecated" ) );
-
-        assertTrue( warnLines.remove(
-            "[WARNING] Parameter 'deprecatedParam' is deprecated: I'm deprecated param" ) );
-
-        assertTrue( warnLines.remove(
-            "[WARNING] Parameter 'deprecatedParam2' (user property 'config.deprecatedParam2') is deprecated: No reason given" ) );
-
-        assertTrue( warnLines.remove(
-            "[WARNING] Parameter 'deprecatedParamWithDefaultConstant' is deprecated: deprecated with constant value" ) );
-
-        assertTrue( warnLines.remove(
-            "[WARNING] Parameter 'deprecatedParamWithDefaultEvaluate' is deprecated: deprecated with evaluate value" ) );
-
-        assertTrue( warnLines.remove(
-            "[WARNING] Parameter 'deprecatedArray' (user property 'config.deprecatedArray') is deprecated: deprecated array" ) );
-
-        assertTrue( warnLines.remove(
-            "[WARNING] Parameter 'deprecatedArrayWithDefaults' is deprecated: deprecated array" ) );
-
-        assertTrue( warnLines.remove(
-            "[WARNING] Parameter 'deprecatedList' (user property 'config.deprecatedList') is deprecated: deprecated list" ) );
-
-        assertTrue( warnLines.remove(
-            "[WARNING] Parameter 'deprecatedListWithDefaults' is deprecated: deprecated list" ) );
-
-        assertTrue( warnLines.remove(
-            "[WARNING] Parameter 'deprecatedProperties' is deprecated: deprecated properties" ) );
-
-        assertTrue( warnLines.remove(
-            "[WARNING] Parameter 'deprecatedMap' is deprecated: deprecated map" ));
-
-        assertTrue( "Not verified line: " + warnLines, warnLines.isEmpty() );
+        assertTrue( logLines.stream().anyMatch(s -> s.contains("Goal 'deprecated-config' is deprecated: This goal is deprecated")) );
+        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedParam' is deprecated: I'm deprecated param")) );
+        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedParam2' (user property 'config.deprecatedParam2') is deprecated: No reason given")) );
+        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedParamWithDefaultConstant' is deprecated: deprecated with constant value")) );
+        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedParamWithDefaultEvaluate' is deprecated: deprecated with evaluate value")) );
+        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedArray' (user property 'config.deprecatedArray') is deprecated: deprecated array")) );
+        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedArrayWithDefaults' is deprecated: deprecated array")) );
+        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedList' (user property 'config.deprecatedList') is deprecated: deprecated list")) );
+        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedListWithDefaults' is deprecated: deprecated list")) );
+        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedProperties' is deprecated: deprecated properties")) );
+        assertTrue( logLines.stream().anyMatch(s -> s.contains("Parameter 'deprecatedMap' is deprecated: deprecated map")) );
 
         Properties configProps = verifier.loadProperties( "target/config.properties" );
 
@@ -252,19 +214,5 @@ public class MavenITmng5222MojoDeprecatedTest
         assertEquals( "value2", configProps.remove( "deprecatedMap.key2" ) );
 
         assertTrue( "not checked config properties: " + configProps, configProps.isEmpty() );
-    }
-
-    private List<String> findDeprecationWarning( List<String> logLines )
-    {
-        Pattern pattern = Pattern.compile( "\\[WARNING] (Parameter|Goal) .* is deprecated:.*" );
-        List<String> result = new ArrayList<>();
-        for ( String line : logLines )
-        {
-            if ( pattern.matcher( line ).matches() )
-            {
-                result.add( line );
-            }
-        }
-        return result;
     }
 }

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5222MojoDeprecatedTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5222MojoDeprecatedTest.java
@@ -63,8 +63,9 @@ public class MavenITmng5222MojoDeprecatedTest
         verifier.verifyErrorFreeLog();
 
         List<String> logLines = verifier.loadFile( verifier.getBasedir(), verifier.getLogFileName(), false );
+        List<String> warnLines = findDeprecationWarning( logLines );
 
-        assertTrue( logLines.stream().anyMatch(s -> s.contains("Goal 'deprecated-config' is deprecated: This goal is deprecated")) );
+        assertTrue( warnLines.stream().anyMatch(s -> s.contains("Goal 'deprecated-config' is deprecated: This goal is deprecated")) );
 
         Properties configProps = verifier.loadProperties( "target/config.properties" );
 

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7464ReadOnlyMojoParametersWarningTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7464ReadOnlyMojoParametersWarningTest.java
@@ -85,10 +85,8 @@ public class MavenITmng7464ReadOnlyMojoParametersWarningTest extends AbstractMav
         List<String> logLines = verifier.loadFile( verifier.getBasedir(), verifier.getLogFileName(), false );
         List<String> warnLines = findReadOnlyWarning( logLines );
 
-        assertTrue( warnLines.remove(
-            "[WARNING] Parameter 'readOnlyWithUserProperty' (user property 'user.property') is read-only, must not be used in configuration" ) );
-
-        assertTrue( "Not verified line: " + warnLines, warnLines.isEmpty() );
+        assertTrue( warnLines.stream().anyMatch( s -> s.contains(
+            "Parameter 'readOnlyWithUserProperty' (user property 'user.property') is read-only, must not be used in configuration" ) ) );
     }
 
     /**
@@ -111,25 +109,22 @@ public class MavenITmng7464ReadOnlyMojoParametersWarningTest extends AbstractMav
         List<String> logLines = verifier.loadFile( verifier.getBasedir(), verifier.getLogFileName(), false );
         List<String> warnLines = findReadOnlyWarning( logLines );
 
-        assertTrue( warnLines.remove(
-            "[WARNING] Parameter 'readOnlyWithDefault' is read-only, must not be used in configuration" ) );
+        assertTrue( warnLines.stream().anyMatch( s -> s.contains(
+            "Parameter 'readOnlyWithDefault' is read-only, must not be used in configuration" ) ) );
 
-        assertTrue( warnLines.remove(
-            "[WARNING] Parameter 'readOnlyWithOutDefaults' is read-only, must not be used in configuration" ) );
+        assertTrue( warnLines.stream().anyMatch( s -> s.contains(
+            "Parameter 'readOnlyWithOutDefaults' is read-only, must not be used in configuration" ) ) );
 
-        assertTrue( warnLines.remove(
-            "[WARNING] Parameter 'readOnlyWithProperty' (user property 'project.version') is read-only, must not be used in configuration" ) );
+        assertTrue( warnLines.stream().anyMatch( s -> s.contains(
+            "Parameter 'readOnlyWithProperty' (user property 'project.version') is read-only, must not be used in configuration" ) ) );
 
-        assertTrue( warnLines.remove(
-            "[WARNING] Parameter 'readOnlyWithUserProperty' (user property 'user.property') is read-only, must not be used in configuration" ) );
-
-        assertTrue( "Not verified line: " + warnLines, warnLines.isEmpty() );
-
+        assertTrue( warnLines.stream().anyMatch( s -> s.contains(
+            "Parameter 'readOnlyWithUserProperty' (user property 'user.property') is read-only, must not be used in configuration" ) ) );
     }
 
     private List<String> findReadOnlyWarning( List<String> logLines )
     {
-        Pattern pattern = Pattern.compile( "\\[WARNING] Parameter .* is read-only.*" );
+        Pattern pattern = Pattern.compile( ".* Parameter .* is read-only.*" );
         List<String> result = new ArrayList<>();
         for ( String line : logLines )
         {


### PR DESCRIPTION
Fixed ITs to not fail:
- assert only for content, neglect and possible indentation
- do not assert what is NOT warn logged, as later we may log more (IT would be not future proof)

Tested with 3.9.1 and 3.9.2-SNAPSHOT w/ https://github.com/apache/maven/pull/1079 Both passes OK

MNG-7754 changes how plugin validation errors are reported (at end and as a dense report), so ITs needs a bit of lax re formatting and indentation and such.

---

https://issues.apache.org/jira/browse/MNG-7754