### PR TITLE
[MNG-7740] Add test for target directory being flooded with consumer*pom files

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7740ConsumerBuildShouldCleanUpOldFilesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7740ConsumerBuildShouldCleanUpOldFilesTest.java
@@ -36,7 +36,7 @@ class MavenITmng7740ConsumerBuildShouldCleanUpOldFilesTest
 
     protected MavenITmng7740ConsumerBuildShouldCleanUpOldFilesTest()
     {
-        super( "[4.0.0-alpha-5,)" );
+        super( "[4.0.0-alpha-6,)" );
     }
 
     @Test
@@ -49,7 +49,6 @@ class MavenITmng7740ConsumerBuildShouldCleanUpOldFilesTest
         verifier.addCliArgument( "validate" );
 
         verifier.execute();
-        verifier.execute();
 
         verifier.verifyErrorFreeLog();
 
@@ -57,7 +56,7 @@ class MavenITmng7740ConsumerBuildShouldCleanUpOldFilesTest
             final List<Path> consumerFiles = stream.filter( path -> path.getFileName().toString().contains("consumer")
                             && path.getFileName().toString().contains( "pom" ))
                     .collect( Collectors.toList());
-            assertTrue("Expected only 1 consumer pom file.", consumerFiles.size() == 1);
+            assertTrue("Expected no consumer pom file.", consumerFiles.size() == 0);
         }
     }
 }

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7740ConsumerBuildShouldCleanUpOldFilesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7740ConsumerBuildShouldCleanUpOldFilesTest.java
@@ -1,0 +1,63 @@
+package org.apache.maven.it;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.shared.verifier.Verifier;
+import org.apache.maven.shared.verifier.util.ResourceExtractor;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class MavenITmng7740ConsumerBuildShouldCleanUpOldFilesTest
+        extends AbstractMavenIntegrationTestCase
+{
+
+    protected MavenITmng7740ConsumerBuildShouldCleanUpOldFilesTest()
+    {
+        super( "[4.0.0-alpha-5,)" );
+    }
+
+    @Test
+    void testConsumerBuildShouldCleanUpOldConsumerFiles()
+            throws Exception
+    {
+        File testDir = ResourceExtractor.simpleExtractResources( getClass(), "/mng-7740-consumer-files" );
+
+        Verifier verifier = newVerifier( testDir.getAbsolutePath() );
+        verifier.addCliArgument( "validate" );
+
+        verifier.execute();
+        verifier.execute();
+
+        verifier.verifyErrorFreeLog();
+
+        try(Stream<Path> stream = Files.walk(testDir.toPath())) {
+            final List<Path> consumerFiles = stream.filter( path -> path.getFileName().toString().contains("consumer")
+                            && path.getFileName().toString().contains( "pom" ))
+                    .collect( Collectors.toList());
+            assertTrue("Expected only 1 consumer pom file.", consumerFiles.size() == 1);
+        }
+    }
+}

--- a/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -111,6 +111,7 @@ public class TestSuiteOrdering implements ClassOrderer
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite( MavenITmng7740ConsumerBuildShouldCleanUpOldFilesTest.class );
         suite.addTestSuite( MavenITmng7038RootdirTest.class );
         suite.addTestSuite( MavenITmng7697PomWithEmojiTest.class );
         suite.addTestSuite( MavenITmng7737ProfileActivationTest.class );

--- a/core-it-suite/src/test/resources/mng-7740-consumer-files/pom.xml
+++ b/core-it-suite/src/test/resources/mng-7740-consumer-files/pom.xml
@@ -1,0 +1,9 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.its.mng7740</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+</project>


### PR DESCRIPTION
For [this PR](https://github.com/apache/maven/pull/1105)