### PR TITLE
[MNG-7788] Fix for IT MavenITmng6562WarnDefaultBindings

### DIFF
--- a/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-resources-plugin/pom.xml
+++ b/core-it-support/core-it-plugins/maven-it-plugin-core-stubs/maven-resources-plugin/pom.xml
@@ -57,7 +57,7 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
+      <artifactId>maven-core</artifactId>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
The MavenITmng6562WarnDefaultBindings IT tests new Maven4 feature "fail on severity" (for WARN level).

The stub core plugin maven-resources-plugin depends on maven-compat, and it emits plugin validation warning.

BEFORE MNG-7788 was merged, the warnings were logged AFTER build summary and was not picked up by "fail on severity".

AFTER MNG-7788 merged, it causes that warnings breaks the build, as "fail on severity" is set to WARN level.

Fix:
The stub maven-resources-plugin does NOT need to depend on maven-compat, what it really needs is maven-core (for MavenProject).