### PR TITLE
[MNG-7891] add an example for a configurable extension

### DIFF
--- a/core-it-suite/src/test/resources/mng-7891-extension-configuration/extension/hello-configuration-extension/pom.xml
+++ b/core-it-suite/src/test/resources/mng-7891-extension-configuration/extension/hello-configuration-extension/pom.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>sample.extension</groupId>
+  <artifactId>hello-configuration-extension</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>maven-plugin</packaging>
+
+  <name>hello-configuration-extension Maven Plugin</name>
+
+  <!-- FIXME change it to the project's website -->
+  <url>http://www.example.com</url>
+
+  <prerequisites>
+    <maven>${maven.version}</maven>
+  </prerequisites>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.version>3.3.9</maven.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-compat</artifactId>
+      <version>${maven.version}</version>
+      <scope>test</scope>
+    </dependency> 
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.6.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-testing</groupId>
+      <artifactId>maven-plugin-testing-harness</artifactId>
+      <version>3.3.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+      <plugins>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <!-- see http://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_maven-plugin_packaging -->
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>3.6.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-invoker-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.6.0</version>
+        <configuration>
+          <!-- <goalPrefix>maven-archetype-plugin</goalPrefix> -->
+          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+        </configuration>
+        <executions>
+          <execution>
+            <id>mojo-descriptor</id>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>help-goal</id>
+            <goals>
+              <goal>helpmojo</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>run-its</id>
+      <build>
+
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-invoker-plugin</artifactId>
+            <version>3.1.0</version>
+            <configuration>
+              <debug>true</debug>
+              <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+              <pomIncludes>
+                <pomInclude>*/pom.xml</pomInclude>
+              </pomIncludes>
+              <postBuildHookScript>verify</postBuildHookScript>
+              <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+              <settingsFile>src/it/settings.xml</settingsFile>
+              <goals>
+                <goal>clean</goal>
+                <goal>test-compile</goal>
+              </goals>
+            </configuration>
+            <executions>
+              <execution>
+                <id>integration-test</id>
+                <goals>
+                  <goal>install</goal>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/core-it-suite/src/test/resources/mng-7891-extension-configuration/extension/hello-configuration-extension/src/main/java/sample/extension/MyLifecycleParticipant.java
+++ b/core-it-suite/src/test/resources/mng-7891-extension-configuration/extension/hello-configuration-extension/src/main/java/sample/extension/MyLifecycleParticipant.java
@@ -1,0 +1,41 @@
+package sample.extension;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.execution.MavenSession;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.logging.Logger;
+
+@Named
+@Singleton
+public class MyLifecycleParticipant extends AbstractMavenLifecycleParticipant {
+
+	private PlexusConfiguration configuration;
+	private Logger logger;
+
+	@Inject
+	public MyLifecycleParticipant(
+			@Named("sample.extension:hello-configuration-extension") PlexusConfiguration configuration, Logger logger) {
+		this.configuration = configuration;
+		this.logger = logger;
+	}
+
+	@Override
+	public void afterSessionStart(MavenSession session) throws MavenExecutionException {
+		PlexusConfiguration messages = configuration.getChild("messages");
+		PlexusConfiguration sessionStart = messages.getChild("sessionStart");
+		logger.info(sessionStart.getValue("No session start message configured"));
+	}
+
+	@Override
+	public void afterProjectsRead(MavenSession session) throws MavenExecutionException {
+		PlexusConfiguration messages = configuration.getChild("messages");
+		PlexusConfiguration sessionStart = messages.getChild("projectsRead");
+		logger.info(sessionStart.getValue("No session projects read message configured"));
+	}
+
+}

--- a/core-it-suite/src/test/resources/mng-7891-extension-configuration/project/core-extension/.mvn/extensions.xml
+++ b/core-it-suite/src/test/resources/mng-7891-extension-configuration/project/core-extension/.mvn/extensions.xml
@@ -1,0 +1,13 @@
+<extensions>
+	<extension>
+		<groupId>sample.extension</groupId>
+		<artifactId>hello-configuration-extension</artifactId>
+		<version>1.0-SNAPSHOT</version>
+		<configuration>
+			<messages>
+				<sessionStart>The session has just started at ${maven.build.timestamp}</sessionStart>
+				<projectsRead>All projects are read now! The build will start and the user has passed -DuserValue=${userValue} on the commandline</projectsRead>
+			</messages>
+		</configuration>
+	</extension>
+</extensions>

--- a/core-it-suite/src/test/resources/mng-7891-extension-configuration/project/core-extension/pom.xml
+++ b/core-it-suite/src/test/resources/mng-7891-extension-configuration/project/core-extension/pom.xml
@@ -1,0 +1,6 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>test</groupId>
+  <artifactId>core-extension</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+</project>


### PR DESCRIPTION
This adds a simple extension that prints out a message at session start and after projects are read.

There is also an example consumer of that extension that configures the message to print the start of the build and the value of a user supplied value on the commandline.