### PR TITLE
Use 1.8 for source/target in ITs - allow to execute by newer JDK

### DIFF
--- a/core-it-suite/src/test/resources/mng-3203/pom.xml
+++ b/core-it-suite/src/test/resources/mng-3203/pom.xml
@@ -43,8 +43,8 @@
                 <execution>
                   <id>default-compile</id>
                   <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <includes>
                       <include>**/Diamond.java</include>
                     </includes>
@@ -70,7 +70,7 @@
                 <execution>
                   <id>default-compile</id>
                   <configuration>
-                    <release>7</release>
+                    <release>8</release>
                   </configuration>
                 </execution>
               </executions>

--- a/core-it-suite/src/test/resources/mng-7045/pom.xml
+++ b/core-it-suite/src/test/resources/mng-7045/pom.xml
@@ -24,8 +24,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.10.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>

--- a/core-it-suite/src/test/resources/mng-7128-block-external-http-reactor/pom.xml
+++ b/core-it-suite/src/test/resources/mng-7128-block-external-http-reactor/pom.xml
@@ -34,8 +34,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.10.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>


### PR DESCRIPTION
1.7 was removed in JDK 20