### PR TITLE
Use 4.0.0-alpha-8 instead of SNAPSHOT

### DIFF
--- a/core-it-suite/src/test/resources-filtered/bootstrap.txt
+++ b/core-it-suite/src/test/resources-filtered/bootstrap.txt
@@ -18,6 +18,8 @@ org.apache.commons:commons-text:1.10.0
 org.apache.geronimo.specs:geronimo-jcdi_2.0_spec:1.3
 org.apache.groovy:groovy-ant:4.0.15
 org.apache.groovy:groovy:4.0.15
+org.apache.maven:maven-api-spi:4.0.0-alpha-8
+org.apache.maven:maven-api-model:4.0.0-alpha-8:mdo
 org.apache.maven.extensions:maven-extensions:40:pom
 org.apache.maven.its.plugins.class-loader:dep-c:${project.version}
 org.apache.maven.its.plugins:maven-it-plugin-active-collection:${project.version}

--- a/core-it-suite/src/test/resources/mng-7836-alternative-pom-syntax/maven-hocon-extension/pom.xml
+++ b/core-it-suite/src/test/resources/mng-7836-alternative-pom-syntax/maven-hocon-extension/pom.xml
@@ -35,13 +35,13 @@ under the License.
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-api-spi</artifactId>
-      <version>4.0.0-alpha-8-SNAPSHOT</version>
+      <version>4.0.0-alpha-8</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-api-core</artifactId>
-      <version>4.0.0-alpha-8-SNAPSHOT</version>
+      <version>4.0.0-alpha-8</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -85,7 +85,7 @@ under the License.
                 <artifactItem>
                   <groupId>org.apache.maven</groupId>
                   <artifactId>maven-api-model</artifactId>
-                  <version>4.0.0-alpha-8-SNAPSHOT</version>
+                  <version>4.0.0-alpha-8</version>
                   <type>mdo</type>
                 </artifactItem>
               </artifactItems>
@@ -107,7 +107,7 @@ under the License.
             <configuration>
               <version>4.2.0</version>
               <models>
-                <model>target/dependency/maven-api-model-4.0.0-alpha-8-SNAPSHOT.mdo</model>
+                <model>target/dependency/maven-api-model-4.0.0-alpha-8.mdo</model>
               </models>
               <templates>
                 <template>src/mdo/hocon-reader.vm</template>


### PR DESCRIPTION
Current Maven master is broken due to the dependency on 4.0.0-alpha-8-SNAPSHOT which are not built anymore, see https://github.com/apache/maven/actions/runs/6767772744/job/18391037312?pr=1297