### PR TITLE
[MNG-7967] Verify javadoc:jar is invoked

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7967ArtifactHandlerLanguageTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7967ArtifactHandlerLanguageTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.shared.verifier.Verifier;
+import org.apache.maven.shared.verifier.util.ResourceExtractor;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test set for
+ * <a href="https://issues.apache.org/jira/browse/MNG-7967">MNG-7967</a>.
+ * Allow to exclude plugins from validation. Affected is Maven 4.0.0-alpha-9.
+ */
+class MavenITmng7967ArtifactHandlerLanguageTest extends AbstractMavenIntegrationTestCase {
+
+    protected MavenITmng7967ArtifactHandlerLanguageTest() {
+        super("(,4.0.0-alpha-9),(4.0.0-alpha-9,)");
+    }
+
+    @Test
+    void javadocIsExecutedAndFailed() throws Exception {
+        File testDir = ResourceExtractor.simpleExtractResources(getClass(), "/mng-7967-artifact-handler-language");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.setLogFileName("with-warning-log.txt");
+        verifier.deleteDirectory("target");
+        verifier.addCliArgument("org.apache.maven.plugins:maven-javadoc-plugin:3.6.3:jar");
+
+        // whatever outcome we do not fail here, but later
+        try {
+            verifier.execute();
+        } catch (VerificationException e) {
+            // skip
+        }
+
+        List<String> logs = verifier.loadLines(verifier.getLogFileName(), null);
+
+        // javadoc:jar uses language to detect is this "Java classpath-capable package"
+        verifyTextNotInLog(logs, "[INFO] Not executing Javadoc as the project is not a Java classpath-capable package");
+
+        // javadoc invocation should actually fail the build
+        verifyTextInLog(logs, "[INFO] BUILD FAILURE");
+
+        // javadoc invocation should actually fail the build
+        verifyTextInLog(logs, "[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin");
+    }
+
+    private void verifyTextInLog(List<String> logs, String text) {
+        assertTrue("Log file not contains: " + text, logs.stream().anyMatch(l -> l.contains(text)));
+    }
+
+    private void verifyTextNotInLog(List<String> logs, String text) {
+        assertFalse("Log file contains: " + text, logs.stream().anyMatch(l -> l.contains(text)));
+    }
+}

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7967ArtifactHandlerLanguageTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7967ArtifactHandlerLanguageTest.java
@@ -42,15 +42,15 @@ class MavenITmng7967ArtifactHandlerLanguageTest extends AbstractMavenIntegration
         File testDir = ResourceExtractor.simpleExtractResources(getClass(), "/mng-7967-artifact-handler-language");
 
         Verifier verifier = newVerifier(testDir.getAbsolutePath());
-        verifier.setLogFileName("with-warning-log.txt");
         verifier.deleteDirectory("target");
         verifier.addCliArgument("org.apache.maven.plugins:maven-javadoc-plugin:3.6.3:jar");
 
+        boolean invocationFailed = false;
         // whatever outcome we do not fail here, but later
         try {
             verifier.execute();
         } catch (VerificationException e) {
-            // skip
+            invocationFailed = true;
         }
 
         List<String> logs = verifier.loadLines(verifier.getLogFileName(), null);
@@ -63,6 +63,8 @@ class MavenITmng7967ArtifactHandlerLanguageTest extends AbstractMavenIntegration
 
         // javadoc invocation should actually fail the build
         verifyTextInLog(logs, "[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin");
+
+        assertTrue("The Maven invocation should have failed: the javadoc should error out", invocationFailed);
     }
 
     private void verifyTextInLog(List<String> logs, String text) {

--- a/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -120,6 +120,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite(MavenITmng7967ArtifactHandlerLanguageTest.class);
         suite.addTestSuite(MavenITmng7939PluginsValidationExcludesTest.class);
         suite.addTestSuite(MavenITmng7837ProjectElementInPomTest.class);
         suite.addTestSuite(MavenITmng7804PluginExecutionOrderTest.class);

--- a/core-it-suite/src/test/resources-filtered/bootstrap.txt
+++ b/core-it-suite/src/test/resources-filtered/bootstrap.txt
@@ -98,6 +98,7 @@ org.apache.maven.plugins:maven-install-plugin:3.0.1
 org.apache.maven.plugins:maven-jar-plugin:${stubPluginVersion}
 org.apache.maven.plugins:maven-jar-plugin:3.3.0
 org.apache.maven.plugins:maven-javadoc-plugin:${stubPluginVersion}
+org.apache.maven.plugins:maven-javadoc-plugin:3.6.3
 org.apache.maven.plugins:maven-plugin-plugin:${stubPluginVersion}
 org.apache.maven.plugins:maven-plugin-plugin:3.2
 org.apache.maven.plugins:maven-plugin-plugin:3.3

--- a/core-it-suite/src/test/resources/mng-7967-artifact-handler-language/pom.xml
+++ b/core-it-suite/src/test/resources/mng-7967-artifact-handler-language/pom.xml
@@ -24,20 +24,4 @@ under the License.
   <artifactId>test</artifactId>
   <version>1.0.0-SNAPSHOT</version>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.its.plugins</groupId>
-        <artifactId>maven-it-plugin-configuration</artifactId>
-        <version>2.1-SNAPSHOT</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>localRepo</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/core-it-suite/src/test/resources/mng-7967-artifact-handler-language/pom.xml
+++ b/core-it-suite/src/test/resources/mng-7967-artifact-handler-language/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.mng7967</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.its.plugins</groupId>
+        <artifactId>maven-it-plugin-configuration</artifactId>
+        <version>2.1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>localRepo</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/core-it-suite/src/test/resources/mng-7967-artifact-handler-language/src/main/java/org/apache/maven/its/mng7967/Sample.java
+++ b/core-it-suite/src/test/resources/mng-7967-artifact-handler-language/src/main/java/org/apache/maven/its/mng7967/Sample.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.its.mng7967;
+
+/**
+ * This is a sample class with broken method javadoc.
+ */
+public class Sample {
+
+    /**
+     * Hello world method, with intentionally brokek javadoc.
+     *
+     * @param where The where is not where but who, is here to fail Javadoc.
+     * @return The "Hello" string.
+     */
+    public String helloWorld(String who) {
+        return "Hello!";
+    }
+}

--- a/core-it-suite/src/test/resources/mng-7967-artifact-handler-language/src/main/java/org/apache/maven/its/mng7967/Sample.java
+++ b/core-it-suite/src/test/resources/mng-7967-artifact-handler-language/src/main/java/org/apache/maven/its/mng7967/Sample.java
@@ -19,12 +19,12 @@
 package org.apache.maven.its.mng7967;
 
 /**
- * This is a sample class with broken method javadoc.
+ * This is a sample class with intentionally broken javadoc on method.
  */
 public class Sample {
 
     /**
-     * Hello world method, with intentionally brokek javadoc.
+     * Hello world method, with intentionally broken javadoc, the params are off.
      *
      * @param where The where is not where but who, is here to fail Javadoc.
      * @return The "Hello" string.


### PR DESCRIPTION
It uses javadoc:jar goal from locked-down version of Javadoc plugin: Bug is that it refuses to run as 4-alpha-9 returns here language="none". If it would run, it would explode, as project contains java source with intentionally broken javadoc.

---

https://issues.apache.org/jira/browse/MNG-7967