### PR TITLE
Update Jetty to 9.4.53.v20231009

### DIFF
--- a/core-it-suite/pom.xml
+++ b/core-it-suite/pom.xml
@@ -78,7 +78,7 @@ under the License.
     <proxy.pass />
     <proxy.nonProxyHosts>localhost</proxy.nonProxyHosts>
     <slf4jVersion>1.6.1</slf4jVersion>
-    <jetty9Version>9.4.50.v20221201</jetty9Version>
+    <jetty9Version>9.4.53.v20231009</jetty9Version>
 
     <stubPluginVersion>0.1-stub-SNAPSHOT</stubPluginVersion>
   </properties>


### PR DESCRIPTION
As currently used one is plagued with CVEs etc.

As long as we are stuck on Java8, we cannot move forward with Jetty, as Jetty 10.x (that is drop in replacement) is Java 11.