### PR TITLE
[MNG-7965] Verify non-parseable POM is detected

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7965PomDuplicateTagsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7965PomDuplicateTagsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.shared.verifier.Verifier;
+import org.apache.maven.shared.verifier.util.ResourceExtractor;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test set for
+ * <a href="https://issues.apache.org/jira/browse/MNG-7965">MNG-7965</a>.
+ * Allow to exclude plugins from validation. Affected is Maven 4.0.0-alpha-9.
+ */
+class MavenITmng7965PomDuplicateTagsTest extends AbstractMavenIntegrationTestCase {
+
+    protected MavenITmng7965PomDuplicateTagsTest() {
+        super("(,4.0.0-alpha-9),(4.0.0-alpha-9,)");
+    }
+
+    @Test
+    void javadocIsExecutedAndFailed() throws Exception {
+        File testDir = ResourceExtractor.simpleExtractResources(getClass(), "/mng-7965-pom-duplicate-tags");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.deleteDirectory("target");
+        verifier.addCliArgument("validate");
+
+        boolean invocationFailed = false;
+        // whatever outcome we do not fail here, but later
+        try {
+            verifier.execute();
+        } catch (VerificationException e) {
+            invocationFailed = true;
+        }
+
+        List<String> logs = verifier.loadLines(verifier.getLogFileName(), null);
+
+        // the POM is not parseable
+        verifyTextInLog(logs, "[FATAL] Non-parseable POM");
+
+        assertTrue("The Maven invocation should have failed: the POM is non-parseable", invocationFailed);
+    }
+
+    private void verifyTextInLog(List<String> logs, String text) {
+        assertTrue("Log file not contains: " + text, logs.stream().anyMatch(l -> l.contains(text)));
+    }
+
+    private void verifyTextNotInLog(List<String> logs, String text) {
+        assertFalse("Log file contains: " + text, logs.stream().anyMatch(l -> l.contains(text)));
+    }
+}

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7965PomDuplicateTagsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7965PomDuplicateTagsTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.it;
 
 import java.io.File;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.Verifier;
@@ -56,12 +57,13 @@ class MavenITmng7965PomDuplicateTagsTest extends AbstractMavenIntegrationTestCas
         List<String> logs = verifier.loadLines(verifier.getLogFileName(), null);
 
         // the POM is not parseable
-        verifyTextInLog(logs, "[FATAL] Non-parseable POM");
+        verifyRegexInLog(logs, "\\[ERROR\\]\\s+Non-parseable POM");
 
         assertTrue("The Maven invocation should have failed: the POM is non-parseable", invocationFailed);
     }
 
-    private void verifyTextInLog(List<String> logs, String text) {
-        assertTrue("Log file not contains: " + text, logs.stream().anyMatch(l -> l.contains(text)));
+    private void verifyRegexInLog(List<String> logs, String text) {
+        Pattern p = Pattern.compile(text);
+        assertTrue("Log file not contains: " + text, logs.stream().anyMatch(p.asPredicate()));
     }
 }

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7965PomDuplicateTagsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7965PomDuplicateTagsTest.java
@@ -64,8 +64,4 @@ class MavenITmng7965PomDuplicateTagsTest extends AbstractMavenIntegrationTestCas
     private void verifyTextInLog(List<String> logs, String text) {
         assertTrue("Log file not contains: " + text, logs.stream().anyMatch(l -> l.contains(text)));
     }
-
-    private void verifyTextNotInLog(List<String> logs, String text) {
-        assertFalse("Log file contains: " + text, logs.stream().anyMatch(l -> l.contains(text)));
-    }
 }

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7965PomDuplicateTagsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7965PomDuplicateTagsTest.java
@@ -29,12 +29,12 @@ import org.junit.jupiter.api.Test;
 /**
  * This is a test set for
  * <a href="https://issues.apache.org/jira/browse/MNG-7965">MNG-7965</a>.
- * Allow to exclude plugins from validation. Affected is Maven 4.0.0-alpha-9.
+ * Allow to exclude plugins from validation. Affected ones as Maven 4.0.0-alpha-8 and Maven 4.0.0-alpha-9.
  */
 class MavenITmng7965PomDuplicateTagsTest extends AbstractMavenIntegrationTestCase {
 
     protected MavenITmng7965PomDuplicateTagsTest() {
-        super("(,4.0.0-alpha-9),(4.0.0-alpha-9,)");
+        super("(,4.0.0-alpha-8),(4.0.0-alpha-9,)");
     }
 
     @Test

--- a/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -120,6 +120,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite(MavenITmng7965PomDuplicateTagsTest.class);
         suite.addTestSuite(MavenITmng7939PluginsValidationExcludesTest.class);
         suite.addTestSuite(MavenITmng7837ProjectElementInPomTest.class);
         suite.addTestSuite(MavenITmng7804PluginExecutionOrderTest.class);

--- a/core-it-suite/src/test/resources/mng-7965-pom-duplicate-tags/pom.xml
+++ b/core-it-suite/src/test/resources/mng-7965-pom-duplicate-tags/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.mng7965</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <repositories>
+    <repository>
+      <id>foo</id>
+      <name>Bar</name>
+      <url>https://really.does.not.matter/</url>
+    </repository>
+  </repositories>
+
+  <repositories>
+    <repository>
+      <id>foo-other</id>
+      <name>Bar The Other</name>
+      <url>https://really.does.not.matter.either/</url>
+    </repository>
+  </repositories>
+
+</project>


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MNG-7965
Main PR: https://github.com/apache/maven/pull/1344

- [MNG-7965] Verify non-parseable POM is detected
- Remove unused
- Adjust maven range
- Fix test
