### PR TITLE
Fix MNG-7819 IT

### DIFF
--- a/core-it-suite/src/test/resources/mng-7819-file-locking-with-snapshots/repo/org/apache/maven/its/mng7819/parent/1.0.0-SNAPSHOT/parent-1.0.0-20221014.203717-12.pom
+++ b/core-it-suite/src/test/resources/mng-7819-file-locking-with-snapshots/repo/org/apache/maven/its/mng7819/parent/1.0.0-SNAPSHOT/parent-1.0.0-20221014.203717-12.pom
@@ -5,4 +5,5 @@
     <groupId>org.apache.maven.its.mng7819</groupId>
     <artifactId>dependency</artifactId>
     <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
 </project>

--- a/core-it-suite/src/test/resources/mng-7819-file-locking-with-snapshots/repo/org/apache/maven/its/mng7819/parent/1.0.0-SNAPSHOT/parent-1.0.0-20221014.203717-12.pom
+++ b/core-it-suite/src/test/resources/mng-7819-file-locking-with-snapshots/repo/org/apache/maven/its/mng7819/parent/1.0.0-SNAPSHOT/parent-1.0.0-20221014.203717-12.pom
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.apache.maven.its.mng7819</groupId>
-    <artifactId>dependency</artifactId>
+    <artifactId>parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 </project>


### PR DESCRIPTION
The goal of IT is to "exercise file locking with snapshots" and not to test model validation.

The IT used dependency had an invalid parent POM w/ wrong packaging.

See IT issue: https://issues.apache.org/jira/browse/MNG-7819