### PR TITLE
[MNG-7758] Report dependency problems for all repository - fix IT

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3477DependencyResolutionErrorMessageTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3477DependencyResolutionErrorMessageTest.java
@@ -57,7 +57,7 @@ public class MavenITmng3477DependencyResolutionErrorMessageTest extends Abstract
             boolean foundCause = false;
             List<String> lines = verifier.loadLines(verifier.getLogFileName(), "UTF-8");
             for (String line : lines) {
-                if (line.matches(".*org.apache.maven.its.mng3477:dep:jar:1.0.*Connection.*refused.*")) {
+                if (line.matches(".*org.apache.maven.its.mng3477:dep:.*:1.0.*Connection.*refused.*")) {
                     foundCause = true;
                     break;
                 }


### PR DESCRIPTION
Old output:

```
[ERROR] Failed to execute goal on project test: Could not resolve dependencies for project org.apache.maven.its.mng3477:test:jar:1: Failed to collect dependencies at org.apache.maven.its.mng3477:dep:jar:1.0: Failed to read artifact descriptor for org.apache.maven.its.mng3477:dep:jar:1.0: The following artifacts could not be resolved: org.apache.maven.its.mng3477:dep:pom:1.0 (absent): Could not transfer artifact org.apache.maven.its.mng3477:dep:pom:1.0 from/to maven-core-it (http://localhost:54312/repo): Connection to http://localhost:54312/repo/ refused: ConnectException: ClosedChannelException -> [Help 1]
```

new:

```
[ERROR] Failed to execute goal on project test: Could not collect dependencies for project org.apache.maven.its.mng3477:test:jar:1
[ERROR] Failed to read artifact descriptor for org.apache.maven.its.mng3477:dep:jar:1.0
[ERROR]         Caused by: The following artifacts could not be resolved: org.apache.maven.its.mng3477:dep:pom:1.0 (absent): Could not transfer artifact org.apache.maven.its.mng3477:dep:pom:1.0 from/to maven-core-it (http://localhost:54312/repo): Connection to http://localhost:54312/repo/ refused

```