### PR TITLE
[MNG-7255] Infer groupId for intra-reactor dependencies

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3863AutoPluginGroupIdTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3863AutoPluginGroupIdTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.Verifier;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.Test;
  * @author Benjamin Bentmann
  *
  */
+@Disabled("MNG-7255 provides the default groupId from the parent")
 public class MavenITmng3863AutoPluginGroupIdTest extends AbstractMavenIntegrationTestCase {
 
     public MavenITmng3863AutoPluginGroupIdTest() {

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7255InferredGroupIdTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng7255InferredGroupIdTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.maven.shared.verifier.VerificationException;
+import org.apache.maven.shared.verifier.Verifier;
+import org.apache.maven.shared.verifier.util.ResourceExtractor;
+import org.junit.jupiter.api.Test;
+
+public class MavenITmng7255InferredGroupIdTest extends AbstractMavenIntegrationTestCase {
+    private static final String PROJECT_PATH = "/mng-7255-inferred-groupid";
+
+    public MavenITmng7255InferredGroupIdTest() {
+        super("[4.0.0-alpha-5,)");
+    }
+
+    @Test
+    public void testInferredGroupId() throws IOException, VerificationException {
+        final File projectDir = ResourceExtractor.simpleExtractResources(getClass(), PROJECT_PATH);
+        final Verifier verifier = newVerifier(projectDir.getAbsolutePath());
+
+        verifier.addCliArgument("validate");
+        verifier.execute();
+
+        verifier.verifyErrorFreeLog();
+    }
+}

--- a/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -120,6 +120,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite(MavenITmng7255InferredGroupIdTest.class);
         suite.addTestSuite(MavenITmng8220ExtensionWithDITest.class);
         suite.addTestSuite(MavenITmng8181CentralRepoTest.class);
         suite.addTestSuite(MavenITmng8123BuildCacheTest.class);

--- a/core-it-suite/src/test/resources/mng-7255-inferred-groupid/child/pom.xml
+++ b/core-it-suite/src/test/resources/mng-7255-inferred-groupid/child/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <parent>
+    <groupId>org.apache.maven.its.mng7255</groupId>
+    <artifactId>parent</artifactId>
+  </parent>
+  <artifactId>child</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <artifactId>dep</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/core-it-suite/src/test/resources/mng-7255-inferred-groupid/dep/pom.xml
+++ b/core-it-suite/src/test/resources/mng-7255-inferred-groupid/dep/pom.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <parent>
+    <groupId>org.apache.maven.its.mng7255</groupId>
+    <artifactId>parent</artifactId>
+  </parent>
+  <artifactId>dep</artifactId>
+  <packaging>jar</packaging>
+</project>

--- a/core-it-suite/src/test/resources/mng-7255-inferred-groupid/pom.xml
+++ b/core-it-suite/src/test/resources/mng-7255-inferred-groupid/pom.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0">
+  <groupId>org.apache.maven.its.mng7255</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+</project>


### PR DESCRIPTION
Main PR: https://github.com/apache/maven/pull/1696