### PR TITLE
[MNG-8267] Disable MNG-5774 ITs for beta-5+

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5774ConfigurationProcessorsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5774ConfigurationProcessorsTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 
 public class MavenITmng5774ConfigurationProcessorsTest extends AbstractMavenIntegrationTestCase {
     public MavenITmng5774ConfigurationProcessorsTest() {
-        super("(3.2.5,)");
+        super("(3.2.5,4.0.0-beta-5)");
     }
 
     @Test

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5774ConfigurationProcessorsTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng5774ConfigurationProcessorsTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 
 public class MavenITmng5774ConfigurationProcessorsTest extends AbstractMavenIntegrationTestCase {
     public MavenITmng5774ConfigurationProcessorsTest() {
-        super("(3.2.5,4.0.0-beta-5)");
+        super("(3.2.5,4.0.0-beta-4]");
     }
 
     @Test

--- a/core-it-suite/src/test/resources-filtered/bootstrap.txt
+++ b/core-it-suite/src/test/resources-filtered/bootstrap.txt
@@ -185,4 +185,5 @@ org.ow2.asm:asm:6.2
 org.ow2.asm:asm:7.2
 org.slf4j:slf4j-api:1.6.1
 org.slf4j:slf4j-api:1.7.36
+org.slf4j:slf4j-api:2.0.16
 org.sonatype.sisu:sisu-guice:jar:no_aop:3.1.0


### PR DESCRIPTION
Also minor fix, but MavenITmng8220ExtensionWithDITest needs slf4j-api 2.0.16 that is not in bootstrap.

---

https://issues.apache.org/jira/browse/MNG-8267