### PR TITLE
[MNG-8340] IT

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8340GeneratedPomInTargetTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng8340GeneratedPomInTargetTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+
+import org.apache.maven.shared.verifier.Verifier;
+import org.apache.maven.shared.verifier.util.ResourceExtractor;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test set for <a href="https://issues.apache.org/jira/browse/MNG-8340">MNG-8340</a>.
+ */
+class MavenITmng8340GeneratedPomInTargetTest extends AbstractMavenIntegrationTestCase {
+
+    MavenITmng8340GeneratedPomInTargetTest() {
+        super("[3.8.6,)");
+    }
+
+    /**
+     *  Verify that the build succeeds.
+     */
+    @Test
+    void testProjectWithShadePluginAndGeneratedPomUnderTarget() throws Exception {
+        File testDir = ResourceExtractor.simpleExtractResources(getClass(), "/mng-8340");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.addCliArgument("package");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+    }
+}

--- a/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -120,6 +120,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * the tests are to finishing. Newer tests are also more likely to fail, so this is
          * a fail fast technique as well.
          */
+        suite.addTestSuite(MavenITmng8340GeneratedPomInTargetTest.class);
         suite.addTestSuite(MavenITmng8360SubprojectProfileActivationTest.class);
         suite.addTestSuite(MavenITmng8347TransitiveDependencyManagerTest.class);
         suite.addTestSuite(MavenITmng8341DeadlockTest.class);

--- a/core-it-suite/src/test/resources/mng-8340/child1/pom.xml
+++ b/core-it-suite/src/test/resources/mng-8340/child1/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.it.mng8340</groupId>
+    <artifactId>root</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>child1</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.16</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <id>shade</id>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <dependencyReducedPomLocation>${basedir}/target/dr-pom.xml</dependencyReducedPomLocation>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/core-it-suite/src/test/resources/mng-8340/child2/pom.xml
+++ b/core-it-suite/src/test/resources/mng-8340/child2/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.it.mng8340</groupId>
+    <artifactId>root</artifactId>
+    <version>1.0.0</version>
+  </parent>
+
+  <artifactId>child2</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.it.mng8340</groupId>
+      <artifactId>child1</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/core-it-suite/src/test/resources/mng-8340/pom.xml
+++ b/core-it-suite/src/test/resources/mng-8340/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.it.mng8340</groupId>
+  <artifactId>root</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>child1</module>
+    <module>child2</module>
+  </modules>
+</project>


### PR DESCRIPTION
Creates error message with beta-5 like:
```
[INFO] --- shade:3.5.0:shade (shade) @ child1 ---
[INFO] Including org.slf4j:slf4j-api:jar:2.0.16 in the shaded jar.
[INFO] Dependency-reduced POM written at: /home/cstamas/Worx/apache-maven/maven-integration-testing/core-it-suite/target/test-classes/mng-8340/child1/target/dr-pom.xml
[WARNING] The top project (/home/cstamas/Worx/apache-maven/maven-integration-testing/core-it-suite/target/test-classes/mng-8340/child1/target/dr-pom.xml) cannot be found in the reactor from root project (/home/cstamas/Worx/apache-maven/maven-integration-testing/pom.xml). Make sure the root directory is correct (a missing '.mvn' directory in the root project is the most common cause) and the project is correctly included in the reactor (missing activated profiles, command line options, etc.). For this build, the top project will be used as the root project.
[WARNING] The top project (/home/cstamas/Worx/apache-maven/maven-integration-testing/core-it-suite/target/test-classes/mng-8340/pom.xml) cannot be found in the reactor from root project (/home/cstamas/Worx/apache-maven/maven-integration-testing/pom.xml). Make sure the root directory is correct (a missing '.mvn' directory in the root project is the most common cause) and the project is correctly included in the reactor (missing activated profiles, command line options, etc.). For this build, the top project will be used as the root project.
[WARNING] child1-1.0.0.jar, slf4j-api-2.0.16.jar define 1 overlapping resource:
[WARNING]   - META-INF/MANIFEST.MF
[WARNING] maven-shade-plugin has detected that some files are
[WARNING] present in two or more JARs. When this happens, only one
[WARNING] single version of the file is copied to the uber jar.
[WARNING] Usually this is not harmful and you can skip these warnings,
[WARNING] otherwise try to manually exclude artifacts based on
[WARNING] mvn dependency:tree -Ddetail=true and the above output.
[WARNING] See https://maven.apache.org/plugins/maven-shade-plugin/
[INFO] Replacing original artifact with shaded artifact.
[INFO] Replacing /home/cstamas/Worx/apache-maven/maven-integration-testing/core-it-suite/target/test-classes/mng-8340/child1/target/child1-1.0.0.jar with /home/cstamas/Worx/apache-maven/maven-integration-testing/core-it-suite/target/test-classes/mng-8340/child1/target/child1-1.0.0-shaded.jar
[INFO] Copying org.apache.maven.it.mng8340:child1:pom:1.0.0 to project local repository
[INFO] Copying org.apache.maven.it.mng8340:child1:jar:1.0.0 to project local repository
[WARNING] Failed to notify spy org.apache.maven.ReactorReader$ReactorReaderSpy: 1 problem was  for org.apache.maven.it.mng8340:child1:jar:1.0.0
    - [FATAL] 'parent.relativePath' points at '../../pom.xml' but no POM could be found, please verify your project structure @ line 3, column 3
```