### PR TITLE
[#12288] Backport ITs for settings.xml profile -> LRM property propagation

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12288SettingsProfileAetherPropertiesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12288SettingsProfileAetherPropertiesTest.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.it;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+import org.apache.maven.shared.verifier.Verifier;
+import org.apache.maven.shared.verifier.util.ResourceExtractor;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests proving that {@code aether.*} properties declared in the
+ * {@code <properties>} block of a {@code settings.xml} profile are honored
+ * by the resolver at local repository manager initialization, regardless of
+ * which settings.xml-only activation channel was used.
+ *
+ * <p>Two activation channels are covered:
+ * <ul>
+ *   <li>{@code <activation><activeByDefault>true</activeByDefault></activation>}
+ *       on the profile itself;</li>
+ *   <li>{@code <activeProfiles><activeProfile>...</activeProfile></activeProfiles>}
+ *       at the top of {@code settings.xml}.</li>
+ * </ul>
+ *
+ * <p>In both cases the same profile sets:
+ * <pre>
+ *   aether.enhancedLocalRepository.split       = true
+ *   aether.enhancedLocalRepository.localPrefix = it-custom-prefix
+ * </pre>
+ * and the test asserts that {@code mvn install} writes the installed pom
+ * under {@code <localRepo>/it-custom-prefix/&lt;groupId-path&gt;/...} rather
+ * than the flat or default-split layout.
+ *
+ * <p>A third test ({@code testActiveByDefaultDeactivatedViaCli}) guards
+ * that {@code -P !profileId} still deactivates an {@code <activeByDefault>}
+ * profile, so its {@code <properties>} are NOT merged into the resolver
+ * session config.
+ *
+ * <p>Backport target: requires the fix from apache/maven PR #12333 to be
+ * present in the running Maven 3.10.x build.
+ */
+public class MavenITgh12288SettingsProfileAetherPropertiesTest extends AbstractMavenIntegrationTestCase {
+
+    public MavenITgh12288SettingsProfileAetherPropertiesTest() {
+        super("[3.10.0-SNAPSHOT,)");
+    }
+
+    @Test
+    public void testActiveByDefaultProfile() throws Exception {
+        runAndAssertCustomPrefix("settings-active-by-default.xml");
+    }
+
+    @Test
+    public void testActiveProfilesList() throws Exception {
+        runAndAssertCustomPrefix("settings-active-profiles-list.xml");
+    }
+
+    @Test
+    public void testActiveByDefaultDeactivatedViaCli() throws Exception {
+        File testDir = ResourceExtractor.simpleExtractResources(
+                getClass(), "/gh-12288-settings-profile-aether-properties");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.setAutoclean(false);
+        verifier.setLogFileName("log-deactivation.txt");
+        verifier.deleteDirectory("target");
+        verifier.deleteArtifacts("org.apache.maven.its.settings.profile.aether");
+
+        File customPrefixSubtree = new File(verifier.getLocalRepository(), "it-custom-prefix");
+        deleteRecursivelyIfExists(customPrefixSubtree);
+
+        verifier.addCliArgument("--settings");
+        verifier.addCliArgument("settings-active-by-default.xml");
+        verifier.addCliArgument("-P!aether-split-via-settings");
+        verifier.addCliArgument("install");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        String localRepo = verifier.getLocalRepository();
+        String gavRelativePath = "org/apache/maven/its/settings/profile/aether/test-artifact/1.0/test-artifact-1.0.pom";
+        File flatLayout = new File(localRepo, gavRelativePath);
+        File customPrefix = new File(localRepo, "it-custom-prefix/" + gavRelativePath);
+
+        assertTrue(
+                "Expected artifact at flat layout (profile deactivated via -P !), but not found at " + flatLayout,
+                flatLayout.exists());
+
+        assertFalse(
+                "Found artifact at custom prefix " + customPrefix + " - deactivation via -P ! was ignored.",
+                customPrefix.exists());
+    }
+
+    private void runAndAssertCustomPrefix(String settingsFile) throws Exception {
+        File testDir = ResourceExtractor.simpleExtractResources(
+                getClass(), "/gh-12288-settings-profile-aether-properties");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.setAutoclean(false);
+        verifier.deleteDirectory("target");
+        verifier.deleteArtifacts("org.apache.maven.its.settings.profile.aether");
+
+        File customPrefixSubtree = new File(verifier.getLocalRepository(), "it-custom-prefix");
+        deleteRecursivelyIfExists(customPrefixSubtree);
+
+        verifier.addCliArgument("--settings");
+        verifier.addCliArgument(settingsFile);
+        verifier.addCliArgument("install");
+        verifier.execute();
+        verifier.verifyErrorFreeLog();
+
+        String localRepo = verifier.getLocalRepository();
+        String gavRelativePath = "org/apache/maven/its/settings/profile/aether/test-artifact/1.0/test-artifact-1.0.pom";
+
+        File expectedAtCustomPrefix = new File(localRepo, "it-custom-prefix/" + gavRelativePath);
+        File flatLayout = new File(localRepo, gavRelativePath);
+        File defaultSplitPrefix = new File(localRepo, "installed/" + gavRelativePath);
+
+        assertTrue(
+                "Expected install to use custom localPrefix 'it-custom-prefix' from "
+                        + settingsFile
+                        + ", but artifact not found at "
+                        + expectedAtCustomPrefix,
+                expectedAtCustomPrefix.exists());
+
+        assertFalse(
+                "Found artifact at flat layout "
+                        + flatLayout
+                        + " - indicates the settings.xml profile properties did not reach the resolver"
+                        + " session config in time for LRM init.",
+                flatLayout.exists());
+
+        assertFalse(
+                "Found artifact at default split-LRM prefix "
+                        + defaultSplitPrefix
+                        + " - indicates split=true was honored but localPrefix was silently dropped.",
+                defaultSplitPrefix.exists());
+    }
+
+    private static void deleteRecursivelyIfExists(File dir) throws IOException {
+        if (!dir.exists()) {
+            return;
+        }
+        Path root = dir.toPath();
+        try (java.util.stream.Stream<Path> walk = Files.walk(root)) {
+            walk.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+        }
+    }
+}

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12288SettingsProfileAetherPropertiesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITgh12288SettingsProfileAetherPropertiesTest.java
@@ -77,8 +77,8 @@ public class MavenITgh12288SettingsProfileAetherPropertiesTest extends AbstractM
 
     @Test
     public void testActiveByDefaultDeactivatedViaCli() throws Exception {
-        File testDir = ResourceExtractor.simpleExtractResources(
-                getClass(), "/gh-12288-settings-profile-aether-properties");
+        File testDir =
+                ResourceExtractor.simpleExtractResources(getClass(), "/gh-12288-settings-profile-aether-properties");
 
         Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);
@@ -111,8 +111,8 @@ public class MavenITgh12288SettingsProfileAetherPropertiesTest extends AbstractM
     }
 
     private void runAndAssertCustomPrefix(String settingsFile) throws Exception {
-        File testDir = ResourceExtractor.simpleExtractResources(
-                getClass(), "/gh-12288-settings-profile-aether-properties");
+        File testDir =
+                ResourceExtractor.simpleExtractResources(getClass(), "/gh-12288-settings-profile-aether-properties");
 
         Verifier verifier = newVerifier(testDir.getAbsolutePath());
         verifier.setAutoclean(false);

--- a/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/TestSuiteOrdering.java
@@ -121,6 +121,7 @@ public class TestSuiteOrdering implements ClassOrderer {
          * a fail fast technique as well.
          */
 
+        suite.addTestSuite(MavenITgh12288SettingsProfileAetherPropertiesTest.class);
         suite.addTestSuite(MavenITgh10312TerminallyDeprecatedMethodInGuiceTest.class);
         suite.addTestSuite(MavenITgh10937QuotedPipesInMavenOptsTest.class);
         suite.addTestSuite(MavenITmng8106OverlappingDirectoryRolesTest.class);

--- a/core-it-suite/src/test/resources/gh-12288-settings-profile-aether-properties/pom.xml
+++ b/core-it-suite/src/test/resources/gh-12288-settings-profile-aether-properties/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.settings.profile.aether</groupId>
+  <artifactId>test-artifact</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <name>Maven Integration Test :: Settings Profile Aether Properties</name>
+  <description>
+    Minimal project for proving that aether.enhancedLocalRepository.*
+    properties set in an active-by-default settings.xml profile are honored
+    by the resolver at local repository manager initialization.
+  </description>
+</project>

--- a/core-it-suite/src/test/resources/gh-12288-settings-profile-aether-properties/pom.xml
+++ b/core-it-suite/src/test/resources/gh-12288-settings-profile-aether-properties/pom.xml
@@ -26,9 +26,7 @@ under the License.
   <packaging>pom</packaging>
 
   <name>Maven Integration Test :: Settings Profile Aether Properties</name>
-  <description>
-    Minimal project for proving that aether.enhancedLocalRepository.*
+  <description>Minimal project for proving that aether.enhancedLocalRepository.*
     properties set in an active-by-default settings.xml profile are honored
-    by the resolver at local repository manager initialization.
-  </description>
+    by the resolver at local repository manager initialization.</description>
 </project>

--- a/core-it-suite/src/test/resources/gh-12288-settings-profile-aether-properties/settings-active-by-default.xml
+++ b/core-it-suite/src/test/resources/gh-12288-settings-profile-aether-properties/settings-active-by-default.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+  <profiles>
+    <profile>
+      <id>aether-split-via-settings</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <aether.enhancedLocalRepository.split>true</aether.enhancedLocalRepository.split>
+        <aether.enhancedLocalRepository.localPrefix>it-custom-prefix</aether.enhancedLocalRepository.localPrefix>
+      </properties>
+    </profile>
+  </profiles>
+</settings>

--- a/core-it-suite/src/test/resources/gh-12288-settings-profile-aether-properties/settings-active-profiles-list.xml
+++ b/core-it-suite/src/test/resources/gh-12288-settings-profile-aether-properties/settings-active-profiles-list.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+  <activeProfiles>
+    <activeProfile>aether-split-via-settings</activeProfile>
+  </activeProfiles>
+  <profiles>
+    <profile>
+      <id>aether-split-via-settings</id>
+      <properties>
+        <aether.enhancedLocalRepository.split>true</aether.enhancedLocalRepository.split>
+        <aether.enhancedLocalRepository.localPrefix>it-custom-prefix</aether.enhancedLocalRepository.localPrefix>
+      </properties>
+    </profile>
+  </profiles>
+</settings>


### PR DESCRIPTION
@gnodet — for review. Companion to apache/maven#12333 (which backports
the core fix from #12297 / #12298 to the maven-3.10.x line).

## What this PR adds

Three integration tests in
`MavenITgh12288SettingsProfileAetherPropertiesTest`:

* `testActiveByDefaultProfile` — guards that a settings.xml profile
  activated via `<activation><activeByDefault>true</activeByDefault>`
  has its `<properties>` (notably `aether.*`) propagated to the resolver
  session config in time for LRM init.
* `testActiveProfilesList` — guards the
  `<activeProfiles><activeProfile>...</activeProfile></activeProfiles>`
  channel that already worked on 3.x. Acts as a regression guard so the
  channel keeps working after the activeByDefault fix.
* `testActiveByDefaultDeactivatedViaCli` — guards that `-P !profileId`
  still deactivates an `<activeByDefault>` profile after the fix, so its
  `<properties>` are NOT merged into the resolver session config.

All three tests use the same fixture artifact
(`org.apache.maven.its.settings.profile.aether:test-artifact:1.0:pom`)
and assert the install location under
`<localRepo>/it-custom-prefix/...` — the place
`aether.enhancedLocalRepository.localPrefix` would land it iff the
properties reach the session config.

## Adaptations from master

Equivalent ITs on apache/maven master were merged via #12297 and #12298.
Ported with the following 3.x conventions:

* `java.io.File` API instead of `java.nio.file.Path`
* `Verifier` from `org.apache.maven.shared.verifier` (3.x package)
* `ResourceExtractor.simpleExtractResources` for fixture extraction
* JUnit-4-style assertions inherited from
  `AbstractMavenIntegrationTestCase`
* Resource directory uses 3.x `gh-NNNN` naming convention
* `super("[3.10.0-SNAPSHOT,)")` so the IT only runs once the core
  backport (apache/maven#12333) lands

## CI behaviour

Until apache/maven#12333 is merged and a Maven 3.10.0 build with the fix
is what the IT-suite runs against, the IT will be **skipped** by the
version-range constraint — green-by-skip is the expected state for now.

## Master origin commits

* apache/maven `7725eaf25ab2715b26848fa56d3f0416862e83cb` — initial 2 ITs
* apache/maven `578523519a33a78a651c472bb07d312e01b1e521` — rename + review hardening
* apache/maven `22f9a0ee086a464f2bfa757ecd0a32053f3d1e8d` — squashed merge of #12298 (added `testActiveByDefaultDeactivatedViaCli`)

References apache/maven#12288, apache/maven#12333.