### PR TITLE
Point the source-tree links at maven-3.10.x rather than master

### DIFF
--- a/core-it-suite/src/site/markdown/bootstrap.md.vm
+++ b/core-it-suite/src/site/markdown/bootstrap.md.vm
@@ -28,7 +28,7 @@ under the License.
 
 Core IT Bootstrapping downloads from Central repository every dependency (artifacts, plugins) required to let Core ITs Suite run without downloading anything later (see [Core ITs Suite and dependencies](./index.html#Core_ITs_Suite_and_Dependencies_.28incl._Plugins.29) rationale).
 
-Content to download is defined in [a series of bootstrap projects](https://github.com/apache/maven-integration-testing/tree/master/core-it-suite/src/test/resources/bootstrap):
+Content to download is defined in [a series of bootstrap projects](https://github.com/apache/maven-integration-testing/tree/maven-3.10.x/core-it-suite/src/test/resources/bootstrap):
 
 <!-- MACRO{toc|section=1|fromDepth=2} -->
 

--- a/core-it-suite/src/site/markdown/index.md.vm
+++ b/core-it-suite/src/site/markdown/index.md.vm
@@ -31,7 +31,7 @@ This module provides the [effective Core Integration Tests suite](./testapidocs/
 Running Core ITs Suite
 ----------------------
 
-Follow the steps that are described in the [README.md](https://github.com/apache/maven-integration-testing/blob/master/README.md) of the official [Core ITs Suite](https://github.com/apache/maven-integration-testing) repository.
+Follow the steps that are described in the [README.md](https://github.com/apache/maven-integration-testing/blob/maven-3.10.x/README.md) of the official [Core ITs Suite](https://github.com/apache/maven-integration-testing) repository.
 
 Core ITs Suite Results
 ----------------------
@@ -49,9 +49,9 @@ Currently deployed [Surefire Report](./surefire-report.html) was generated with 
 Core ITs Suite and Dependencies (incl. Plugins)
 -----------------------------------------------
 
-A good IT does not depend on external repos like Central, it uses dedicated test plugins and test repositories. The [default `settings.xml`](https://github.com/apache/maven-integration-testing/blob/master/core-it-suite/src/test/resources-filtered/settings.xml) used by ITs helps to enforce this by pointing `central` at `file:target/null`, which obviously can't resolve anything. This setup using a file-based dummy repo also helps execution time, because this repo produces (expected) `404`s much faster than a HTTP-based repo.
+A good IT does not depend on external repos like Central, it uses dedicated test plugins and test repositories. The [default `settings.xml`](https://github.com/apache/maven-integration-testing/blob/maven-3.10.x/core-it-suite/src/test/resources-filtered/settings.xml) used by ITs helps to enforce this by pointing `central` at `file:target/null`, which obviously can't resolve anything. This setup using a file-based dummy repo also helps execution time, because this repo produces (expected) `404`s much faster than a HTTP-based repo.
 
-The one place where access to Central is desired is by adding artifacts to the [bootstrap.txt](https://github.com/apache/maven-integration-testing/blob/master/core-it-suite/src/test/resources/bootstrap.txt) file, which is used to prime the local repo with any artifacts the ITs will need. This file should be kept sorted alphabetically for ease of use.
+The one place where access to Central is desired is by adding artifacts to the [bootstrap.txt](https://github.com/apache/maven-integration-testing/blob/maven-3.10.x/core-it-suite/src/test/resources-filtered/bootstrap.txt) file, which is used to prime the local repo with any artifacts the ITs will need. This file should be kept sorted alphabetically for ease of use.
 
 So some care needs to be taken when introducing new dependencies into the ITs themselves or [the support plugins](../core-it-support/). Many times the failures that we encounter are discrepancies between actual artifact consumption required and what is populated during bootstrapping. When forgetting, typical failures (as seen in ASF CI) will give following traces in log:
 


### PR DESCRIPTION
Four links on the Core ITs Suite pages address files by way of this repository's `master` branch. Master was emptied to a four-file stub when the IT tree moved into `apache/maven` (commit "Branch 3.10.x created"), so three of the four now return **404**, and the fourth reaches a signpost README rather than the instructions the sentence promises.

Base branch: **`maven-3.10.x`**.

**Stacked on #433** — the pages only exist in Markdown form after that PR, so this branch is built on top of it and the diff shown here includes its two commits until it merges. **Merge #433 first**; this PR's own change is the single commit `Point the source-tree links at maven-3.10.x rather than master`, two files, four lines.

### What changes

| link | before | after |
| --- | --- | --- |
| `README.md` | `blob/master/README.md` — 200, but master's README is now just a list of surviving branches | `blob/maven-3.10.x/README.md` |
| default `settings.xml` | `blob/master/core-it-suite/src/test/resources-filtered/settings.xml` — **404** | `blob/maven-3.10.x/…` |
| `bootstrap.txt` | `blob/master/core-it-suite/src/test/**resources**/bootstrap.txt` — **404** | `blob/maven-3.10.x/core-it-suite/src/test/**resources-filtered**/bootstrap.txt` |
| bootstrap projects | `tree/master/core-it-suite/src/test/resources/bootstrap` — **404** | `tree/maven-3.10.x/…` |

Two notes on the choices:

* **`bootstrap.txt` was also addressing the wrong directory**, independently of the branch — the file is under `src/test/resources-filtered`, not `src/test/resources`, so that link would have been dead on any ref. Both errors are fixed together.
* **`maven-3.10.x` rather than a tag or `master`.** The branch is what this site is built from, so the page and the tree it describes stay in step; a tag would freeze and drift. Master is what got us here, and it got there by being emptied rather than by being a branch. The bare repository-root link ("the official Core ITs Suite repository") is left alone — it resolves and is meant to name the repository, not a ref.

### Verification

* Every rewritten URL fetched with `curl -L`: all four return **200**, `url_effective` unchanged, so no redirect to a repository root. The three replaced ones were confirmed **404** first.
* `mvn -N site` in `core-it-suite`, exit 0, compared against the build from #433's head: **the four link targets are the only difference** in the generated pages.

### Not addressed here

`<scm><tag>master</tag></scm>` in the POM, with `<url>…/tree/${project.scm.tag}</url>`, points the generated "edit this page" link on every page and the source-repository report into the same emptied master. That is release metadata rather than documentation, and `maven-3.9.x` carries it identically, so it wants a committer's decision across both branches rather than a drive-by change in a docs PR.

<sub>Drafted with Claude — please verify</sub>
