### PR TITLE
Upgrade Maven parent to 49 and cleanups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven-parent</artifactId>
-    <version>45</version>
+    <version>49</version>
     <relativePath />
   </parent>
 
@@ -75,7 +75,7 @@ under the License.
     <maven.compiler.target>8</maven.compiler.target>
 
     <maven-version>3.8.6</maven-version>
-    <maven-plugin-tools-version>3.6.4</maven-plugin-tools-version>
+    <version.maven-plugin-tools>3.6.4</version.maven-plugin-tools>
   </properties>
 
   <dependencyManagement>
@@ -128,12 +128,12 @@ under the License.
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-tools-java</artifactId>
-        <version>${maven-plugin-tools-version}</version>
+        <version>${version.maven-plugin-tools}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>
-        <version>${maven-plugin-tools-version}</version>
+        <version>${version.maven-plugin-tools}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -157,27 +157,6 @@ under the License.
   <build>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <configuration>
-            <tagletArtifacts>
-              <tagletArtifact>
-                <groupId>org.apache.maven.plugin-tools</groupId>
-                <artifactId>maven-plugin-tools-javadoc</artifactId>
-                <version>3.5.2</version>
-              </tagletArtifact>
-            </tagletArtifacts>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-scm-publish-plugin</artifactId>
-          <version>1.1</version>
-          <configuration>
-            <serverId>apache.releases.https</serverId>
-          </configuration>
-        </plugin>
         <!--This plugin's configuration is used to store Eclipse m2e settings
           only. It has no influence on the Maven build itself. -->
         <plugin>
@@ -203,21 +182,6 @@ under the License.
               </pluginExecutions>
             </lifecycleMappingMetadata>
           </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-resources-plugin</artifactId>
-          <version>3.2.0</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-plugin-plugin</artifactId>
-          <version>${maven-plugin-tools-version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-component-metadata</artifactId>
-          <version>2.2.0</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
- Bump maven-parent to 49
- Rename `maven-plugin-tools-version` property to `version.maven-plugin-tools`
- Remove unused and redundant plugin configurations