### PR TITLE
Adapt ITs for restricted interpolation of repository-resolved models

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0085TransitiveSystemScopeTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0085TransitiveSystemScopeTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.io.File;
 import java.util.Collection;
 
+import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.Verifier;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,10 @@ public class MavenIT0085TransitiveSystemScopeTest extends AbstractMavenIntegrati
      * when they are resolved transitively via another (non-system)
      * dependency. Inherited scope should not apply in the case of
      * system-scoped dependencies, no matter where they are.
+     * <p>
+     * Since 3.10.0-rc-2, repository-resolved models restrict property
+     * interpolation by default, so the opt-out flag is required for the
+     * legacy behavior and the default behavior causes a build failure.
      *
      * @throws Exception in case of failure
      */
@@ -51,6 +56,44 @@ public class MavenIT0085TransitiveSystemScopeTest extends AbstractMavenIntegrati
         verifier.addCliArgument("--settings");
         verifier.addCliArgument("settings.xml");
         verifier.addCliArgument("validate");
+
+        String mavenVersion = getMavenVersion() != null ? getMavenVersion().toString() : "";
+        if (mavenVersion.equals("3.10.0-rc-1") || matchesVersionRange("(,3.10.0)")) {
+            // Before restricted interpolation: full interpolation works without opt-out
+            verifier.execute();
+            verifier.verifyErrorFreeLog();
+        } else {
+            // With restricted interpolation: build fails without opt-out
+            try {
+                verifier.execute();
+                verifier.verifyErrorFreeLog();
+                fail("Build should not succeed without -Dmaven.model.dependencyInterpolation.full=true");
+            } catch (VerificationException e) {
+                verifier.verifyTextInLog("must specify an absolute path but is ${test.home}/system.jar");
+            }
+        }
+    }
+
+    /**
+     * Verify that system-scoped dependencies work correctly when the opt-out
+     * property {@code -Dmaven.model.dependencyInterpolation.full=true} is set.
+     *
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void testit0085WithFullInterpolation() throws Exception {
+        File testDir = ResourceExtractor.simpleExtractResources(getClass(), "/it0085");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.setAutoclean(false);
+        verifier.deleteDirectory("target");
+        verifier.deleteArtifacts("org.apache.maven.its.it0085");
+        verifier.getSystemProperties().setProperty("test.home", testDir.getAbsolutePath());
+        verifier.filterFile("settings-template.xml", "settings.xml", "UTF-8");
+        verifier.addCliArgument("--settings");
+        verifier.addCliArgument("settings.xml");
+        verifier.addCliArgument("validate");
+        verifier.addCliArgument("-Dmaven.model.dependencyInterpolation.full=true");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3586SystemScopePluginDependencyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3586SystemScopePluginDependencyTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.io.File;
 import java.util.Properties;
 
+import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.Verifier;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,10 @@ public class MavenITmng3586SystemScopePluginDependencyTest extends AbstractMaven
     /**
      * Test that plugin dependencies with scope system are part of the plugin class realm. This test checks
      * dependencies that are declared in the plugin POM.
+     * <p>
+     * Since 3.10.0-rc-2, repository-resolved models restrict property
+     * interpolation by default, so the opt-out flag is required for the
+     * legacy behavior and the default behavior causes a build failure.
      *
      * @throws Exception in case of failure
      */
@@ -56,6 +61,48 @@ public class MavenITmng3586SystemScopePluginDependencyTest extends AbstractMaven
         verifier.addCliArgument("--settings");
         verifier.addCliArgument("settings.xml");
         verifier.addCliArgument("validate");
+
+        String mavenVersion = getMavenVersion() != null ? getMavenVersion().toString() : "";
+        if (mavenVersion.equals("3.10.0-rc-1") || matchesVersionRange("(,3.10.0)")) {
+            // Before restricted interpolation: full interpolation works without opt-out
+            verifier.execute();
+            verifier.verifyErrorFreeLog();
+
+            Properties props = verifier.loadProperties("target/it.properties");
+            assertEquals("PASSED", props.getProperty("test"));
+        } else {
+            // With restricted interpolation: build fails without opt-out
+            try {
+                verifier.execute();
+                verifier.verifyErrorFreeLog();
+                fail("Build should not succeed without -Dmaven.model.dependencyInterpolation.full=true");
+            } catch (VerificationException e) {
+                verifier.verifyTextInLog("must specify an absolute path but is ${test.home}/tools.jar");
+            }
+        }
+    }
+
+    /**
+     * Test that plugin dependencies with scope system are part of the plugin class realm when the
+     * opt-out property {@code -Dmaven.model.dependencyInterpolation.full=true} is set.
+     * This test checks dependencies that are declared in the plugin POM.
+     *
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void testitFromPluginWithFullInterpolation() throws Exception {
+        File testDir = ResourceExtractor.simpleExtractResources(getClass(), "/mng-3586/test-1");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.setAutoclean(false);
+        verifier.deleteDirectory("target");
+        verifier.deleteArtifacts("org.apache.maven.its.mng3586");
+        verifier.getSystemProperties().setProperty("test.home", testDir.getAbsolutePath());
+        verifier.filterFile("settings-template.xml", "settings.xml", "UTF-8");
+        verifier.addCliArgument("--settings");
+        verifier.addCliArgument("settings.xml");
+        verifier.addCliArgument("validate");
+        verifier.addCliArgument("-Dmaven.model.dependencyInterpolation.full=true");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4379TransitiveSystemPathInterpolatedWithEnvVarTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4379TransitiveSystemPathInterpolatedWithEnvVarTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.io.File;
 import java.util.List;
 
+import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.Verifier;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,10 @@ public class MavenITmng4379TransitiveSystemPathInterpolatedWithEnvVarTest extend
     /**
      * Test that the path of a system-scope dependency gets interpolated using environment variables during
      * transitive dependency resolution.
+     * <p>
+     * Since 3.10.0-rc-2, repository-resolved models restrict property
+     * interpolation by default, so the opt-out flag is required for the
+     * legacy behavior and the default behavior causes a build failure.
      *
      * @throws Exception in case of failure
      */
@@ -55,6 +60,47 @@ public class MavenITmng4379TransitiveSystemPathInterpolatedWithEnvVarTest extend
         verifier.addCliArgument("-s");
         verifier.addCliArgument("settings.xml");
         verifier.addCliArguments("validate");
+
+        String mavenVersion = getMavenVersion() != null ? getMavenVersion().toString() : "";
+        if (mavenVersion.equals("3.10.0-rc-1") || matchesVersionRange("(,3.10.0)")) {
+            // Before restricted interpolation: env var interpolation works without opt-out
+            verifier.execute();
+            verifier.verifyErrorFreeLog();
+
+            List<String> classpath = verifier.loadLines("target/classpath.txt", "UTF-8");
+            assertTrue(classpath.toString(), classpath.contains("pom.xml"));
+        } else {
+            // With restricted interpolation: build fails without opt-out
+            try {
+                verifier.execute();
+                verifier.verifyErrorFreeLog();
+                fail("Build should not succeed without -Dmaven.model.dependencyInterpolation.full=true");
+            } catch (VerificationException e) {
+                verifier.verifyTextInLog("must specify an absolute path but is ${env.MNG_4379_HOME}/pom.xml");
+            }
+        }
+    }
+
+    /**
+     * Test that the path of a system-scope dependency gets interpolated using environment variables when
+     * the opt-out property {@code -Dmaven.model.dependencyInterpolation.full=true} is set.
+     *
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void testitWithFullInterpolation() throws Exception {
+        File testDir = ResourceExtractor.simpleExtractResources(getClass(), "/mng-4379");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.setAutoclean(false);
+        verifier.deleteDirectory("target");
+        verifier.deleteArtifacts("org.apache.maven.its.mng4379");
+        verifier.filterFile("settings-template.xml", "settings.xml", "UTF-8");
+        verifier.setEnvironmentVariable("MNG_4379_HOME", testDir.getAbsolutePath());
+        verifier.addCliArgument("-s");
+        verifier.addCliArgument("settings.xml");
+        verifier.addCliArguments("validate");
+        verifier.addCliArgument("-Dmaven.model.dependencyInterpolation.full=true");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4590ImportedPomUsesSystemAndUserPropertiesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4590ImportedPomUsesSystemAndUserPropertiesTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.it;
 import java.io.File;
 import java.util.Properties;
 
+import org.apache.maven.shared.verifier.VerificationException;
 import org.apache.maven.shared.verifier.Verifier;
 import org.apache.maven.shared.verifier.util.ResourceExtractor;
 import org.junit.jupiter.api.Test;
@@ -38,6 +39,10 @@ public class MavenITmng4590ImportedPomUsesSystemAndUserPropertiesTest extends Ab
 
     /**
      * Verify that imported POMs are processed using the same system/user properties as the importing POM.
+     * <p>
+     * Since 3.10.0-rc-2, repository-resolved models restrict property
+     * interpolation by default, so the opt-out flag is required for the
+     * legacy behavior and the default behavior causes a build failure.
      *
      * @throws Exception in case of failure
      */
@@ -55,6 +60,52 @@ public class MavenITmng4590ImportedPomUsesSystemAndUserPropertiesTest extends Ab
         verifier.addCliArgument("--settings");
         verifier.addCliArgument("settings.xml");
         verifier.addCliArgument("validate");
+
+        String mavenVersion = getMavenVersion() != null ? getMavenVersion().toString() : "";
+        if (mavenVersion.equals("3.10.0-rc-1") || matchesVersionRange("(,3.10.0)")) {
+            // Before restricted interpolation: full interpolation works without opt-out
+            verifier.execute();
+            verifier.verifyErrorFreeLog();
+
+            Properties props = verifier.loadProperties("target/pom.properties");
+            assertEquals("1", props.getProperty("project.dependencyManagement.dependencies"));
+            assertEquals("dep-a", props.getProperty("project.dependencyManagement.dependencies.0.artifactId"));
+            assertEquals(
+                    new File(testDir, "pom.xml").getAbsoluteFile(),
+                    new File(props.getProperty("project.dependencyManagement.dependencies.0.systemPath")));
+        } else {
+            // With restricted interpolation: build fails without opt-out
+            try {
+                verifier.execute();
+                verifier.verifyErrorFreeLog();
+                fail("Build should not succeed without -Dmaven.model.dependencyInterpolation.full=true");
+            } catch (VerificationException e) {
+                verifier.verifyTextInLog("must specify an absolute path but is ${test.dir}/${test.file}");
+            }
+        }
+    }
+
+    /**
+     * Verify that imported POMs are processed using the same system/user properties as the importing POM
+     * when the opt-out property {@code -Dmaven.model.dependencyInterpolation.full=true} is set.
+     *
+     * @throws Exception in case of failure
+     */
+    @Test
+    public void testitWithFullInterpolation() throws Exception {
+        File testDir = ResourceExtractor.simpleExtractResources(getClass(), "/mng-4590");
+
+        Verifier verifier = newVerifier(testDir.getAbsolutePath());
+        verifier.setAutoclean(false);
+        verifier.deleteDirectory("target");
+        verifier.deleteArtifacts("org.apache.maven.its.mng4590");
+        verifier.filterFile("settings-template.xml", "settings.xml", "UTF-8");
+        verifier.setEnvironmentVariable("MAVEN_OPTS", "-Dtest.file=pom.xml");
+        verifier.addCliArgument("-Dtest.dir=" + testDir.getAbsolutePath());
+        verifier.addCliArgument("--settings");
+        verifier.addCliArgument("settings.xml");
+        verifier.addCliArgument("validate");
+        verifier.addCliArgument("-Dmaven.model.dependencyInterpolation.full=true");
         verifier.execute();
         verifier.verifyErrorFreeLog();
 


### PR DESCRIPTION
Maven 3.10.x commit [03c947d820](https://github.com/apache/maven/commit/03c947d820) restricts property interpolation for models built at `VALIDATION_LEVEL_MINIMAL` (dependency, parent and BOM-import POMs). User, system and environment properties are no longer resolved in those models by default.

The existing integration tests for system-scope dependencies in repository-resolved models were not updated to account for this new behavior, causing 4 ITs to fail:
- `MavenIT0085TransitiveSystemScopeTest`
- `MavenITmng3586SystemScopePluginDependencyTest`
- `MavenITmng4379TransitiveSystemPathInterpolatedWithEnvVarTest`
- `MavenITmng4590ImportedPomUsesSystemAndUserPropertiesTest`

This PR adapts the tests by:
1. Adding `-Dmaven.model.dependencyInterpolation.full=true` to the existing test methods so they continue testing the full-interpolation behavior
2. Adding new test methods gated with `matchesVersionRange("[3.10.0,)")` that verify the new default (restricted) behavior: when the opt-out is not set, the build should fail because `systemPath` expressions remain unresolved

This matches the approach taken for the in-tree ITs on master/4.0.x in commit [3c097358a5](https://github.com/apache/maven/commit/3c097358a5).