### PR TITLE
Update ITs for stricter validation in Maven 3.10.x (PR apache/maven#1542)

### DIFF
--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0085TransitiveSystemScopeTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenIT0085TransitiveSystemScopeTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 public class MavenIT0085TransitiveSystemScopeTest extends AbstractMavenIntegrationTestCase {
     public MavenIT0085TransitiveSystemScopeTest() {
-        super(ALL_MAVEN_VERSIONS);
+        super("(,3.10.0-alpha-1)");
     }
 
     /**

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1701DuplicatePluginTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng1701DuplicatePluginTest.java
@@ -56,7 +56,7 @@ public class MavenITmng1701DuplicatePluginTest extends AbstractMavenIntegrationT
         }
 
         String logLevel;
-        if (matchesVersionRange("(,4.0.0-alpha-1)")) {
+        if (matchesVersionRange("(,3.10.0-alpha-1)")) {
             logLevel = "WARNING";
         } else {
             logLevel = "ERROR";

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3586SystemScopePluginDependencyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3586SystemScopePluginDependencyTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 public class MavenITmng3586SystemScopePluginDependencyTest extends AbstractMavenIntegrationTestCase {
 
     public MavenITmng3586SystemScopePluginDependencyTest() {
-        super(ALL_MAVEN_VERSIONS);
+        super("(,3.10.0-alpha-1)");
     }
 
     /**

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3719PomExecutionOrderingTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng3719PomExecutionOrderingTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 public class MavenITmng3719PomExecutionOrderingTest extends AbstractMavenIntegrationTestCase {
 
     public MavenITmng3719PomExecutionOrderingTest() {
-        super("[2.0.11,2.1.0-M1),[2.1.0-M2,4.0.0-alpha-1)");
+        super("[2.0.11,2.1.0-M1),[2.1.0-M2,3.10.0-alpha-1)");
     }
 
     /**

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4005UniqueDependencyKeyTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4005UniqueDependencyKeyTest.java
@@ -91,7 +91,7 @@ public class MavenITmng4005UniqueDependencyKeyTest extends AbstractMavenIntegrat
         }
 
         String logLevel;
-        if (matchesVersionRange("(,4.0.0-alpha-1)")) {
+        if (matchesVersionRange("(,3.10.0-alpha-1)")) {
             logLevel = "WARNING";
         } else {
             logLevel = "ERROR";

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4379TransitiveSystemPathInterpolatedWithEnvVarTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4379TransitiveSystemPathInterpolatedWithEnvVarTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 public class MavenITmng4379TransitiveSystemPathInterpolatedWithEnvVarTest extends AbstractMavenIntegrationTestCase {
 
     public MavenITmng4379TransitiveSystemPathInterpolatedWithEnvVarTest() {
-        super("[2.0.3,2.1.0),[3.0-alpha-6,)");
+        super("[2.0.3,2.1.0),[3.0-alpha-6,3.10.0-alpha-1)");
     }
 
     /**

--- a/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4590ImportedPomUsesSystemAndUserPropertiesTest.java
+++ b/core-it-suite/src/test/java/org/apache/maven/it/MavenITmng4590ImportedPomUsesSystemAndUserPropertiesTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 public class MavenITmng4590ImportedPomUsesSystemAndUserPropertiesTest extends AbstractMavenIntegrationTestCase {
 
     public MavenITmng4590ImportedPomUsesSystemAndUserPropertiesTest() {
-        super("[2.0.9,3.0-alpha-1),[3.0-beta-1,)");
+        super("[2.0.9,3.0-alpha-1),[3.0-beta-1,3.10.0-alpha-1)");
     }
 
     /**


### PR DESCRIPTION
Companion PR for https://github.com/apache/maven/pull/1542 which changes `VALIDATION_LEVEL_STRICT` from `MAVEN_3_0` to `MAVEN_3_1`, promoting several checks from WARNING to ERROR.

**Changes:**
- `MavenITmng4005` / `MavenITmng1701`: adjust WARNING→ERROR version boundary to `3.10.0-alpha-1`
- `MavenITmng3719`: exclude for 3.10.0+ (relies on duplicate plugin merge, now rejected)
- `MavenITmng4379`, `MavenITmng4590`, `MavenITmng3586`, `MavenIT0085`: exclude for 3.10.0+ (system scope validation now stricter)

See https://github.com/apache/maven/pull/1542 for details.